### PR TITLE
Fix container management API and terminal server

### DIFF
--- a/back/app/Http/Controllers/ContainersController.php
+++ b/back/app/Http/Controllers/ContainersController.php
@@ -49,9 +49,14 @@ class ContainersController extends Controller
         };
     }
 
+    public function logs(string $id)
+    {
+        return response()->json(['logs' => $this->docker->containerLogs($id)]);
+    }
+
     public function inspect(string $id)
     {
-        return response()->json($this->docker->inspectContainer($id));
+        return response()->json($this->docker->containerInspect($id));
     }
 
     public function binds(string $id)

--- a/back/app/Services/DockerService.php
+++ b/back/app/Services/DockerService.php
@@ -129,7 +129,12 @@ class DockerService
 
     public function containerLogs(string $id, int $tail = 200): string
     {
-        $stream = $this->docker->containerLogs($id, ['stdout' => true, 'stderr' => true, 'tail' => $tail]);
+        // docker-php expects the tail option as string
+        $stream = $this->docker->containerLogs($id, [
+            'stdout' => true,
+            'stderr' => true,
+            'tail'   => (string) $tail,
+        ]);
         $output = '';
         foreach ($stream->getBody()->getIterator() as $chunk) {
             $output .= $chunk;

--- a/back/app/Services/DockerService.php
+++ b/back/app/Services/DockerService.php
@@ -47,6 +47,11 @@ class DockerService
         $cfg = new ContainersCreatePostBody();
         $cfg->setImage($options['image']);
         $cfg->setTty(true);
+        // allow attaching a terminal later
+        $cfg->setOpenStdin(true);
+        $cfg->setAttachStdin(true);
+        $cfg->setAttachStdout(true);
+        $cfg->setAttachStderr(true);
 
         // --- ENV & CMD ---
         if (!empty($options['cmd'])) {
@@ -146,5 +151,15 @@ class DockerService
     {
         $info = $this->containerInspect($id);
         return $info->getMounts() ?? [];
+    }
+
+    public function attachTerminal(string $id)
+    {
+        return $this->docker->containerAttachWebsocket($id, [
+            'stream' => true,
+            'stdin'  => true,
+            'stdout' => true,
+            'stderr' => true,
+        ]);
     }
 }

--- a/back/app/Services/DockerService.php
+++ b/back/app/Services/DockerService.php
@@ -167,4 +167,14 @@ class DockerService
             'stderr' => true,
         ]);
     }
+
+    public function attachLogs(string $id)
+    {
+        return $this->docker->containerAttachWebsocket($id, [
+            'stream' => true,
+            'stdout' => true,
+            'stderr' => true,
+            'logs'   => true,
+        ]);
+    }
 }

--- a/back/app/WebSockets/TerminalServer.php
+++ b/back/app/WebSockets/TerminalServer.php
@@ -3,8 +3,8 @@ namespace App\WebSockets;
 
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
-use Symfony\Component\Process\Process;
 use React\EventLoop\Loop;
+use App\Services\DockerService;
 
 class TerminalServer implements MessageComponentInterface
 {
@@ -18,47 +18,36 @@ class TerminalServer implements MessageComponentInterface
             $conn->close();
             return;
         }
-        $cmd = ['docker', 'exec', '-it', $containerId, '/bin/sh'];
-        $process = new Process($cmd);
-        if (DIRECTORY_SEPARATOR !== '\\') {
-            $process->setPty(true);
-        }
-        $process->start();
-        $timer = Loop::addPeriodicTimer(0.1, function() use ($conn, $process) {
-            if (!$process->isRunning()) {
+        $docker = new DockerService();
+        $stream = $docker->attachTerminal($containerId);
+
+        $timer = Loop::addPeriodicTimer(0.1, function() use ($conn, $stream) {
+            $out = $stream->read(0, 200000);
+            if ($out === null) {
+                $conn->close();
                 return;
             }
-            $out = $process->getIncrementalOutput() . $process->getIncrementalErrorOutput();
-            if ($out !== '') {
+            if ($out !== false && $out !== '') {
                 $conn->send($out);
             }
         });
-        $this->clients[$conn->resourceId] = [$conn, $process, $timer];
+
+        $this->clients[$conn->resourceId] = [$conn, $stream, $timer];
     }
 
     public function onMessage(ConnectionInterface $from, $msg)
     {
-        [$conn, $process, $timer] = $this->clients[$from->resourceId];
-        if (!$process->isRunning()) {
-            return;
-        }
+        [$conn, $stream, $timer] = $this->clients[$from->resourceId];
         $data = json_decode($msg, true);
         if (isset($data['type']) && $data['type'] === 'input') {
-            $process->getInput()->write($data['data']);
-        } elseif (isset($data['type']) && $data['type'] === 'resize') {
-            // ignore for now
-        } else {
-            $process->getInput()->write($msg);
+            $stream->write($data['data']);
         }
     }
 
     public function onClose(ConnectionInterface $conn)
     {
-        [$c, $process, $timer] = $this->clients[$conn->resourceId];
+        [$c, $stream, $timer] = $this->clients[$conn->resourceId];
         Loop::cancelTimer($timer);
-        if ($process->isRunning()) {
-            $process->stop(0);
-        }
         unset($this->clients[$conn->resourceId]);
     }
 

--- a/back/app/WebSockets/TerminalServer.php
+++ b/back/app/WebSockets/TerminalServer.php
@@ -18,8 +18,11 @@ class TerminalServer implements MessageComponentInterface
             $conn->close();
             return;
         }
+        $mode = $query['mode'] ?? 'terminal';
         $docker = new DockerService();
-        $stream = $docker->attachTerminal($containerId);
+        $stream = $mode === 'logs'
+            ? $docker->attachLogs($containerId)
+            : $docker->attachTerminal($containerId);
 
         $timer = Loop::addPeriodicTimer(0.1, function() use ($conn, $stream) {
             $out = $stream->read(0, 200000);
@@ -32,21 +35,23 @@ class TerminalServer implements MessageComponentInterface
             }
         });
 
-        $this->clients[$conn->resourceId] = [$conn, $stream, $timer];
+        $this->clients[$conn->resourceId] = [$conn, $stream, $timer, $mode];
     }
 
     public function onMessage(ConnectionInterface $from, $msg)
     {
-        [$conn, $stream, $timer] = $this->clients[$from->resourceId];
-        $data = json_decode($msg, true);
-        if (isset($data['type']) && $data['type'] === 'input') {
-            $stream->write($data['data']);
+        [$conn, $stream, $timer, $mode] = $this->clients[$from->resourceId];
+        if ($mode === 'terminal') {
+            $data = json_decode($msg, true);
+            if (isset($data['type']) && $data['type'] === 'input') {
+                $stream->write($data['data']);
+            }
         }
     }
 
     public function onClose(ConnectionInterface $conn)
     {
-        [$c, $stream, $timer] = $this->clients[$conn->resourceId];
+        [$c, $stream, $timer, $mode] = $this->clients[$conn->resourceId];
         Loop::cancelTimer($timer);
         unset($this->clients[$conn->resourceId]);
     }

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -54,4 +54,7 @@ Route::prefix('containers')->group(function () {
     Route::post('/', [\App\Http\Controllers\ContainersController::class, 'store']);
     Route::post('/{id}', [\App\Http\Controllers\ContainersController::class, 'action']);
     Route::get('/{id}', [\App\Http\Controllers\ContainersController::class, 'get']);
+    Route::get('/{id}/logs', [\App\Http\Controllers\ContainersController::class, 'logs']);
+    Route::get('/{id}/inspect', [\App\Http\Controllers\ContainersController::class, 'inspect']);
+    Route::get('/{id}/binds', [\App\Http\Controllers\ContainersController::class, 'binds']);
 });

--- a/src/components/scenario/ContainerLogsModal.tsx
+++ b/src/components/scenario/ContainerLogsModal.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress } from '@mui/material';
+import React, { useEffect, useRef, useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box } from '@mui/material';
 
-const API_BASE = "http://localhost:8000";
+const LOG_WS = 'ws://localhost:8080';
 
 interface ContainerLogsModalProps {
   open: boolean;
@@ -11,31 +11,24 @@ interface ContainerLogsModalProps {
 
 const ContainerLogsModal: React.FC<ContainerLogsModalProps> = ({ open, containerId, onClose }) => {
   const [logs, setLogs] = useState('');
-  const [loading, setLoading] = useState(false);
+  const socketRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
-    if (open && containerId) {
-      setLoading(true);
-      fetch(`${API_BASE}/api/containers/${containerId}/logs`)
-        .then(res => res.json())
-        .then(data => setLogs(data.logs || ''))
-        .finally(() => setLoading(false));
-    }
+    if (!open || !containerId) return;
+    setLogs('');
+    const ws = new WebSocket(`${LOG_WS}?mode=logs&id=${containerId}`);
+    socketRef.current = ws;
+    ws.onmessage = e => setLogs(l => l + e.data);
+    return () => ws.close();
   }, [open, containerId]);
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>容器日志</DialogTitle>
       <DialogContent dividers>
-        {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
-            <CircularProgress />
-          </Box>
-        ) : (
-          <Box component="pre" sx={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
-            {logs || '无日志'}
-          </Box>
-        )}
+        <Box component="pre" sx={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+          {logs || '无日志'}
+        </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} variant="outlined">关闭</Button>


### PR DESCRIPTION
## Summary
- add terminal attach support in DockerService
- expose logs/inspect/binds routes
- adapt ContainersController for separate endpoints
- allow interactive terminals in createContainer
- rework TerminalServer to use docker-php attach websocket

## Testing
- `php -l app/Services/DockerService.php`
- `php -l app/Http/Controllers/ContainersController.php`
- `php -l app/WebSockets/TerminalServer.php`
- `php -l routes/api.php`
- `./vendor/bin/phpunit --testsuite Unit`

------
https://chatgpt.com/codex/tasks/task_e_685d294722588320882f9b296e899627