### PR TITLE
Enhance instance modals UI and persist exec terminal

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,13 +2,16 @@
 import React from 'react';
 import { AppThemeProvider } from '@/contexts/ThemeModeContext';
 import { AuthProvider } from '@/contexts/AuthContext';
+import { ExecTerminalProvider } from '@/contexts/ExecTerminalContext';
 import CssBaseline from '@mui/material/CssBaseline';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <AppThemeProvider>
       <CssBaseline />
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <ExecTerminalProvider>{children}</ExecTerminalProvider>
+      </AuthProvider>
     </AppThemeProvider>
   );
 }

--- a/src/app/scenario/instances/page.tsx
+++ b/src/app/scenario/instances/page.tsx
@@ -46,7 +46,7 @@ import ConfirmActionDialog from '@/components/scenario/ConfirmActionDialog';
 import ContainerLogsModal from '@/components/scenario/ContainerLogsModal';
 import ContainerInspectModal from '@/components/scenario/ContainerInspectModal';
 import BindMountsModal from '@/components/scenario/BindMountsModal';
-import ExecTerminalModal from '@/components/scenario/ExecTerminalModal';
+import { useExecTerminal } from '@/contexts/ExecTerminalContext';
 import CreateContainerModal from '@/components/scenario/CreateContainerModal';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -77,7 +77,7 @@ const RunningInstancesPage: React.FC = () => {
     const [logsModalId, setLogsModalId] = useState<string | null>(null);
     const [inspectModalId, setInspectModalId] = useState<string | null>(null);
     const [bindsModalId, setBindsModalId] = useState<string | null>(null);
-    const [execModalIds, setExecModalIds] = useState<string[]>([]);
+    const { openTerminal } = useExecTerminal();
     const [showColumns, setShowColumns] = useState({
         id: true,
         imageName: true,
@@ -402,7 +402,7 @@ const RunningInstancesPage: React.FC = () => {
                 <MenuItem onClick={() => { setBindsModalId(moreMenuAnchor.id); setMoreMenuAnchor({ anchor: null, id: null }); }}>
                     Bind mounts
                 </MenuItem>
-                <MenuItem onClick={() => { if (moreMenuAnchor.id) setExecModalIds(ids => ids.includes(moreMenuAnchor.id!) ? ids : [...ids, moreMenuAnchor.id!]); setMoreMenuAnchor({ anchor: null, id: null }); }}>
+                <MenuItem onClick={() => { if (moreMenuAnchor.id) openTerminal(moreMenuAnchor.id); setMoreMenuAnchor({ anchor: null, id: null }); }}>
                     Terminal
                 </MenuItem>
             </Menu>
@@ -430,14 +430,6 @@ const RunningInstancesPage: React.FC = () => {
             <ContainerLogsModal open={Boolean(logsModalId)} containerId={logsModalId} onClose={() => setLogsModalId(null)} />
             <ContainerInspectModal open={Boolean(inspectModalId)} containerId={inspectModalId} onClose={() => setInspectModalId(null)} />
             <BindMountsModal open={Boolean(bindsModalId)} containerId={bindsModalId} onClose={() => setBindsModalId(null)} />
-            {execModalIds.map(id => (
-                <ExecTerminalModal
-                    key={id}
-                    open
-                    containerId={id}
-                    onClose={() => setExecModalIds(ids => ids.filter(i => i !== id))}
-                />
-            ))}
             <CreateContainerModal
                 open={createModalOpen}
                 onClose={() => setCreateModalOpen(false)}

--- a/src/components/scenario/BindMountsModal.tsx
+++ b/src/components/scenario/BindMountsModal.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress, List, ListItem, ListItemText } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress, Table, TableHead, TableRow, TableCell, TableBody, Slide, useTheme } from '@mui/material';
+import { TransitionProps } from '@mui/material/transitions';
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children: React.ReactElement<any, any> },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
 
 interface BindMountsModalProps {
     open: boolean;
@@ -10,6 +18,7 @@ interface BindMountsModalProps {
 const BindMountsModal: React.FC<BindMountsModalProps> = ({ open, containerId, onClose }) => {
     const [mounts, setMounts] = useState<any[]>([]);
     const [loading, setLoading] = useState(false);
+    const theme = useTheme();
 
     useEffect(() => {
         if (open && containerId) {
@@ -22,22 +31,40 @@ const BindMountsModal: React.FC<BindMountsModalProps> = ({ open, containerId, on
     }, [open, containerId]);
 
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-            <DialogTitle>绑定挂载</DialogTitle>
-            <DialogContent dividers>
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="sm"
+            fullWidth
+            TransitionComponent={Transition}
+        >
+            <DialogTitle sx={{ bgcolor: theme.palette.mode === 'dark' ? 'grey.800' : 'grey.100' }}>
+                绑定挂载
+            </DialogTitle>
+            <DialogContent dividers sx={{ p: 0 }}>
                 {loading ? (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
                         <CircularProgress />
                     </Box>
+                ) : mounts.length === 0 ? (
+                    <Box sx={{ p: 2 }}>无挂载</Box>
                 ) : (
-                    <List>
-                        {mounts.map((m, idx) => (
-                            <ListItem key={idx} divider>
-                                <ListItemText primary={m.Source} secondary={m.Destination} />
-                            </ListItem>
-                        ))}
-                        {mounts.length === 0 && <Box sx={{ p:2 }}>无挂载</Box>}
-                    </List>
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>源</TableCell>
+                                <TableCell>目标</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {mounts.map((m, idx) => (
+                                <TableRow key={idx}>
+                                    <TableCell>{m.Source}</TableCell>
+                                    <TableCell>{m.Destination}</TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
                 )}
             </DialogContent>
             <DialogActions>

--- a/src/components/scenario/ContainerInspectModal.tsx
+++ b/src/components/scenario/ContainerInspectModal.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress, useTheme, Slide } from '@mui/material';
+import { TransitionProps } from '@mui/material/transitions';
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children: React.ReactElement<any, any> },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
 
 const API_BASE = "http://localhost:8000";
 
@@ -12,6 +20,7 @@ interface ContainerInspectModalProps {
 const ContainerInspectModal: React.FC<ContainerInspectModalProps> = ({ open, containerId, onClose }) => {
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(false);
+  const theme = useTheme();
 
   useEffect(() => {
     if (open && containerId) {
@@ -24,15 +33,33 @@ const ContainerInspectModal: React.FC<ContainerInspectModalProps> = ({ open, con
   }, [open, containerId]);
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>容器 Inspect</DialogTitle>
-      <DialogContent dividers>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      TransitionComponent={Transition}
+    >
+      <DialogTitle sx={{ bgcolor: theme.palette.mode === 'dark' ? 'grey.800' : 'grey.100' }}>
+        容器 Inspect
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0 }}>
         {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
             <CircularProgress />
           </Box>
         ) : (
-          <Box component="pre" sx={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+          <Box
+            component="pre"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              fontFamily: 'monospace',
+              bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'grey.50',
+              p: 2,
+              m: 0,
+              overflow: 'auto',
+            }}
+          >
             {data ? JSON.stringify(data, null, 2) : '无数据'}
           </Box>
         )}
@@ -45,3 +72,4 @@ const ContainerInspectModal: React.FC<ContainerInspectModalProps> = ({ open, con
 };
 
 export default ContainerInspectModal;
+

--- a/src/components/scenario/ContainerLogsModal.tsx
+++ b/src/components/scenario/ContainerLogsModal.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, CircularProgress, useTheme, Slide } from '@mui/material';
+import { TransitionProps } from '@mui/material/transitions';
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & { children: React.ReactElement<any, any> },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />;
+});
 
 interface ContainerLogsModalProps {
     open: boolean;
@@ -10,6 +18,7 @@ interface ContainerLogsModalProps {
 const ContainerLogsModal: React.FC<ContainerLogsModalProps> = ({ open, containerId, onClose }) => {
     const [logs, setLogs] = useState('');
     const [loading, setLoading] = useState(false);
+    const theme = useTheme();
 
     useEffect(() => {
         if (open && containerId) {
@@ -22,15 +31,33 @@ const ContainerLogsModal: React.FC<ContainerLogsModalProps> = ({ open, container
     }, [open, containerId]);
 
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-            <DialogTitle>容器日志</DialogTitle>
-            <DialogContent dividers>
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="md"
+            fullWidth
+            TransitionComponent={Transition}
+        >
+            <DialogTitle sx={{ bgcolor: theme.palette.mode === 'dark' ? 'grey.800' : 'grey.100' }}>
+                容器日志
+            </DialogTitle>
+            <DialogContent dividers sx={{ p: 0 }}>
                 {loading ? (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
                         <CircularProgress />
                     </Box>
                 ) : (
-                    <Box component="pre" sx={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+                    <Box
+                        component="pre"
+                        sx={{
+                            whiteSpace: 'pre-wrap',
+                            fontFamily: 'monospace',
+                            bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'grey.50',
+                            p: 2,
+                            m: 0,
+                            overflow: 'auto',
+                        }}
+                    >
                         {logs || '无日志'}
                     </Box>
                 )}

--- a/src/components/scenario/ExecTerminalModal.tsx
+++ b/src/components/scenario/ExecTerminalModal.tsx
@@ -25,6 +25,7 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
   const fitAddonRef = useRef<any>(null);
   const [minimized, setMinimized] = useState(false);
   const [maximized, setMaximized] = useState(false);
+  const prevMinRef = useRef<{ position: { x: number; y: number }; size: { width: number; height: number } } | null>(null);
   const [position, setPosition] = useState(() => ({
     x:
         typeof window !== 'undefined'
@@ -132,7 +133,23 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
         >
           <Box>{containerId ? `终端 ${containerId.slice(0, 12)}` : '终端'}</Box>
           <Box>
-            <IconButton size="small" onClick={() => setMinimized(!minimized)}>
+            <IconButton
+              size="small"
+              onClick={() => {
+                if (minimized) {
+                  if (prevMinRef.current) {
+                    setPosition(prevMinRef.current.position);
+                    setSize(prevMinRef.current.size);
+                  }
+                  setMinimized(false);
+                } else {
+                  prevMinRef.current = { position, size };
+                  setPosition({ x: window.innerWidth - 260, y: window.innerHeight - 56 });
+                  setSize({ width: 240, height: 40 });
+                  setMinimized(true);
+                }
+              }}
+            >
               {minimized ? <OpenInFullIcon fontSize="inherit" /> : <MinimizeIcon fontSize="inherit" />}
             </IconButton>
             {!minimized && (
@@ -165,27 +182,20 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
             </IconButton>
           </Box>
         </Box>
-        {!minimized && (
-            <Box sx={{ flex: 1, bgcolor: 'black', position: 'relative', borderBottomLeftRadius: 8, borderBottomRightRadius: 8 }}>
-              <div ref={wrapperRef} style={{ position: 'absolute', inset: 0 }} />
-            </Box>
-        )}
+        <Box
+            sx={{
+              flex: 1,
+              bgcolor: 'black',
+              position: 'relative',
+              borderBottomLeftRadius: 8,
+              borderBottomRightRadius: 8,
+              display: minimized ? 'none' : 'block',
+            }}
+        >
+          <div ref={wrapperRef} style={{ position: 'absolute', inset: 0 }} />
+        </Box>
       </Paper>
   );
-
-  if (minimized) {
-    return (
-        <Box sx={{ position: 'fixed', bottom: 16, right: 16, width: 240, zIndex: 1300 }} ref={dragRef}>
-          {paper}
-        </Box>
-    );
-  }
-
-  if (maximized) {
-    return (
-        <Box sx={{ position: 'fixed', inset: 0, zIndex: 1300 }}>{paper}</Box>
-    );
-  }
 
   return (
       <Rnd
@@ -200,6 +210,8 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
           minHeight={200}
           bounds="window"
           dragHandleClassName="terminal-title"
+          enableResizing={!minimized && !maximized}
+          disableDragging={maximized}
           style={{ zIndex: 1300, position: 'fixed' }}
       >
         {paper}

--- a/src/components/scenario/ExecTerminalModal.tsx
+++ b/src/components/scenario/ExecTerminalModal.tsx
@@ -206,8 +206,8 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
             setSize({ width: parseInt(ref.style.width, 10), height: parseInt(ref.style.height, 10) });
             setPosition(pos);
           }}
-          minWidth={300}
-          minHeight={200}
+          minWidth={minimized ? 240 : 300}
+          minHeight={minimized ? 40 : 200}
           bounds="window"
           dragHandleClassName="terminal-title"
           enableResizing={!minimized && !maximized}

--- a/src/components/scenario/ExecTerminalModal.tsx
+++ b/src/components/scenario/ExecTerminalModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useRef, useState } from 'react';
 import { Rnd } from 'react-rnd';
-import { Box, IconButton, Paper } from '@mui/material';
+import { Box, IconButton, Paper, useTheme } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import MinimizeIcon from '@mui/icons-material/Minimize';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
@@ -17,6 +17,7 @@ interface ExecTerminalModalProps {
 }
 
 export default function ExecTerminalModal({ open, containerId, onClose }: ExecTerminalModalProps) {
+  const theme = useTheme();
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<any>();
   const socketRef = useRef<Socket | null>(null);
@@ -102,7 +103,14 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
 
   const paper = (
       <Paper
-          sx={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            borderRadius: 2,
+            bgcolor: theme.palette.background.paper,
+          }}
           elevation={8}
           ref={dragRef}
       >
@@ -115,7 +123,11 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
               bgcolor: 'primary.main',
               color: 'primary.contrastText',
               p: 1,
+              pl: 2,
+              pr: 1,
               cursor: 'move',
+              borderTopLeftRadius: 8,
+              borderTopRightRadius: 8,
             }}
         >
           <Box>{containerId ? `终端 ${containerId.slice(0, 12)}` : '终端'}</Box>
@@ -154,7 +166,7 @@ export default function ExecTerminalModal({ open, containerId, onClose }: ExecTe
           </Box>
         </Box>
         {!minimized && (
-            <Box sx={{ flex: 1, bgcolor: 'black', position: 'relative' }}>
+            <Box sx={{ flex: 1, bgcolor: 'black', position: 'relative', borderBottomLeftRadius: 8, borderBottomRightRadius: 8 }}>
               <div ref={wrapperRef} style={{ position: 'absolute', inset: 0 }} />
             </Box>
         )}

--- a/src/contexts/ExecTerminalContext.tsx
+++ b/src/contexts/ExecTerminalContext.tsx
@@ -1,0 +1,37 @@
+"use client";
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import ExecTerminalModal from '@/components/scenario/ExecTerminalModal';
+
+interface ExecTerminalContextProps {
+  openTerminals: string[];
+  openTerminal: (id: string) => void;
+  closeTerminal: (id: string) => void;
+}
+
+const ExecTerminalContext = createContext<ExecTerminalContextProps | undefined>(undefined);
+
+export const ExecTerminalProvider = ({ children }: { children: ReactNode }) => {
+  const [openTerminals, setOpenTerminals] = useState<string[]>([]);
+
+  const openTerminal = (id: string) =>
+    setOpenTerminals(t => (t.includes(id) ? t : [...t, id]));
+
+  const closeTerminal = (id: string) =>
+    setOpenTerminals(t => t.filter(i => i !== id));
+
+  return (
+    <ExecTerminalContext.Provider value={{ openTerminals, openTerminal, closeTerminal }}>
+      {children}
+      {openTerminals.map(id => (
+        <ExecTerminalModal key={id} open containerId={id} onClose={() => closeTerminal(id)} />
+      ))}
+    </ExecTerminalContext.Provider>
+  );
+};
+
+export const useExecTerminal = () => {
+  const ctx = useContext(ExecTerminalContext);
+  if (!ctx) throw new Error('useExecTerminal must be used within ExecTerminalProvider');
+  return ctx;
+};
+


### PR DESCRIPTION
## Summary
- improve style for logs, inspect and mount modals using MUI components
- modernize the draggable exec terminal window
- keep exec terminal windows alive across page navigation

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e1c0fae7c8320843ee8bf04b7faf2