### PR TITLE
Update menu labels and add VM management pages

### DIFF
--- a/src/app/AppContent.tsx
+++ b/src/app/AppContent.tsx
@@ -22,6 +22,8 @@ const ROUTE_PERMISSIONS = [
   { prefix: '/admin/roles', key: 'ADMIN_ROLES_MANAGE' },
   { prefix: '/scenario/images', key: 'SCENARIO_IMAGES_MANAGE' },
   { prefix: '/scenario/instances', key: 'SCENARIO_INSTANCES_MANAGE' },
+  { prefix: '/scenario/vm-images', key: 'SCENARIO_IMAGES_MANAGE' },
+  { prefix: '/scenario/vm-instances', key: 'SCENARIO_INSTANCES_MANAGE' },
 ];
 
 export default function AppContent({ children }: { children: React.ReactNode }) {

--- a/src/app/scenario/images/page.tsx
+++ b/src/app/scenario/images/page.tsx
@@ -188,7 +188,7 @@ const ImageManagementPage: React.FC = () => {
     <Box sx={{ p: 3 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-          <Typography variant="h4" component="h1">镜像管理</Typography>
+          <Typography variant="h4" component="h1">容器镜像管理</Typography>
           <TextField
             variant="outlined"
             placeholder="搜索镜像..."

--- a/src/app/scenario/images/page.tsx
+++ b/src/app/scenario/images/page.tsx
@@ -141,7 +141,6 @@ const ImageManagementPage: React.FC = () => {
     { field: 'size', headerName: '大小', flex: 1, hide: !showColumns.size },
     { field: 'uploadDate', headerName: '上传日期', flex: 1, hide: !showColumns.uploadDate,
       valueFormatter: (params) => {
-        console.log('value =>', params);     // 会是 undefined 吗？
         return dayjs(params).format('YYYY年M月D日');
       }
     },

--- a/src/app/scenario/instances/page.tsx
+++ b/src/app/scenario/instances/page.tsx
@@ -306,7 +306,7 @@ const RunningInstancesPage: React.FC = () => {
         <Box sx={{ p: { xs: 2, sm: 3 } }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-                    <Typography variant="h4" component="h1">实例管理</Typography>
+                    <Typography variant="h4" component="h1">容器实例管理</Typography>
                     <TextField
                         variant="outlined"
                         placeholder="搜索容器 (名称, ID, 镜像)..."

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Box, Typography } from '@mui/material';
+
+const VmImageManagementPage: React.FC = () => {
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1">虚拟机镜像管理</Typography>
+    </Box>
+  );
+};
+
+export default VmImageManagementPage;

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Box, Typography } from '@mui/material';
+
+const VmInstanceManagementPage: React.FC = () => {
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1">虚拟机实例管理</Typography>
+    </Box>
+  );
+};
+
+export default VmInstanceManagementPage;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -67,7 +67,14 @@ const Sidebar: React.FC<SidebarProps> = ({ drawerWidth }) => {
     if (currentPath.startsWith('/learn')) initialOpenMenus["人员测试分系统"] = true;
     if (currentPath.startsWith('/scenario')) initialOpenMenus["环境构建分系统"] = true;
     if (currentPath.startsWith('/drill')) initialOpenMenus["安全实验分系统"] = true; // Updated key
-    if (currentPath.startsWith('/admin') || currentPath.startsWith('/scenario/images') || currentPath.startsWith('/scenario/instances') ) initialOpenMenus["基础支撑分系统"] = true; // Updated to open if viewing moved items
+    if (
+      currentPath.startsWith('/admin') ||
+      currentPath.startsWith('/scenario/images') ||
+      currentPath.startsWith('/scenario/instances') ||
+      currentPath.startsWith('/scenario/vm-images') ||
+      currentPath.startsWith('/scenario/vm-instances')
+    )
+      initialOpenMenus["基础支撑分系统"] = true; // Updated to open if viewing moved items
     return initialOpenMenus;
   });
 
@@ -111,8 +118,10 @@ const Sidebar: React.FC<SidebarProps> = ({ drawerWidth }) => {
       children: [
         { to: "/admin/users", label: "用户管理", icon: UserGroupIcon, requiredPermission: 'ADMIN_USERS_MANAGE' },
         { to: "/admin/roles", label: "角色管理", icon: KeyIcon, requiredPermission: 'ADMIN_ROLES_MANAGE' },
-        { to: "/scenario/images", label: "镜像管理", icon: ArchiveBoxIconHero, requiredPermission: 'SCENARIO_IMAGES_MANAGE' }, // Moved here
-        { to: "/scenario/instances", label: "实例管理", icon: CommandLineIcon, requiredPermission: 'SCENARIO_INSTANCES_MANAGE' } // Moved here
+        { to: "/scenario/images", label: "容器镜像管理", icon: ArchiveBoxIconHero, requiredPermission: 'SCENARIO_IMAGES_MANAGE' }, // Moved here and renamed
+        { to: "/scenario/instances", label: "容器实例管理", icon: CommandLineIcon, requiredPermission: 'SCENARIO_INSTANCES_MANAGE' }, // Moved here and renamed
+        { to: "/scenario/vm-images", label: "虚拟机镜像管理", icon: ArchiveBoxIconHero, requiredPermission: 'SCENARIO_IMAGES_MANAGE' },
+        { to: "/scenario/vm-instances", label: "虚拟机实例管理", icon: ComputerDesktopIconHero, requiredPermission: 'SCENARIO_INSTANCES_MANAGE' }
       ]
     },
   ];


### PR DESCRIPTION
## Summary
- rename sidebar labels to clarify container image and instance management
- auto-open sidebar menu for new VM sections
- create new blank pages for **虚拟机镜像管理** and **虚拟机实例管理**
- register new routes in permission checks

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e30c2e7048320b8142403914f9873