### PR TITLE
Unify style of VM management pages

### DIFF
--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -1,17 +1,10 @@
 "use client"
 
-import type React from "react"
-import { useState, useEffect } from "react"
+import React, { useState, useEffect, useMemo } from "react"
 import {
     Box,
     Typography,
     Button,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
     Paper,
     IconButton,
     Chip,
@@ -27,6 +20,7 @@ import {
     Select,
     Alert,
     Tooltip,
+    useTheme,
 } from "@mui/material"
 import {
     Add as AddIcon,
@@ -37,6 +31,7 @@ import {
     Computer as ComputerIcon,
     Search as SearchIcon,
 } from "@mui/icons-material"
+import { DataGrid, GridColDef } from "@mui/x-data-grid"
 
 interface VmImage {
     id: string
@@ -156,12 +151,15 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
         handleCloseDialog()
     }
 
-const [search, setSearch] = useState('')
-const filteredImages = images.filter(img =>
-    img.name.toLowerCase().includes(search.toLowerCase()) ||
-    img.version.toLowerCase().includes(search.toLowerCase()) ||
-    img.description.toLowerCase().includes(search.toLowerCase())
-)
+    const theme = useTheme()
+    const [search, setSearch] = useState('')
+    const [page, setPage] = useState(0)
+    const [rowsPerPage, setRowsPerPage] = useState(10)
+    const filteredImages = images.filter(img =>
+        img.name.toLowerCase().includes(search.toLowerCase()) ||
+        img.version.toLowerCase().includes(search.toLowerCase()) ||
+        img.description.toLowerCase().includes(search.toLowerCase())
+    )
 
     const handleDelete = (id: string) => {
         if (confirm("确定要删除这个虚拟机镜像吗？")) {
@@ -195,6 +193,67 @@ const filteredImages = images.filter(img =>
         }
     }
 
+    const columns = useMemo<GridColDef[]>(() => [
+        {
+            field: 'name',
+            headerName: '镜像名称',
+            flex: 1,
+            minWidth: 180,
+            renderCell: params => (
+                <Box>
+                    <Typography variant="subtitle2">{params.row.name}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                        {params.row.description}
+                    </Typography>
+                </Box>
+            ),
+        },
+        { field: 'version', headerName: '版本', width: 120 },
+        { field: 'osType', headerName: '操作系统', width: 120 },
+        { field: 'architecture', headerName: '架构', width: 120 },
+        { field: 'size', headerName: '大小', width: 120 },
+        {
+            field: 'status',
+            headerName: '状态',
+            width: 120,
+            renderCell: params => (
+                <Chip label={getStatusText(params.row.status)} color={getStatusColor(params.row.status)} size="small" />
+            ),
+        },
+        {
+            field: 'uploadDate',
+            headerName: '上传时间',
+            flex: 1,
+            minWidth: 160,
+            valueFormatter: params => new Date(params.value as string).toLocaleString('zh-CN'),
+        },
+        {
+            field: 'actions',
+            headerName: '操作',
+            sortable: false,
+            width: 140,
+            renderCell: params => (
+                <Box>
+                    <Tooltip title="查看详情">
+                        <IconButton size="small">
+                            <ViewIcon />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="编辑">
+                        <IconButton size="small" onClick={() => handleOpenDialog(params.row)}>
+                            <EditIcon />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="删除">
+                        <IconButton size="small" onClick={() => handleDelete(params.row.id)}>
+                            <DeleteIcon />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
+            ),
+        },
+    ], [images])
+
     return (
         <Box sx={{ p: 3 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
@@ -218,59 +277,17 @@ const filteredImages = images.filter(img =>
                 </Button>
             </Box>
 
-            <TableContainer component={Paper} sx={{ boxShadow: 3 }}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>镜像名称</TableCell>
-                            <TableCell>版本</TableCell>
-                            <TableCell>操作系统</TableCell>
-                            <TableCell>架构</TableCell>
-                            <TableCell>大小</TableCell>
-                            <TableCell>状态</TableCell>
-                            <TableCell>上传时间</TableCell>
-                            <TableCell>操作</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {filteredImages.map((image) => (
-                            <TableRow key={image.id}>
-                                <TableCell>
-                                    <Typography variant="subtitle2">{image.name}</Typography>
-                                    <Typography variant="caption" color="text.secondary">
-                                        {image.description}
-                                    </Typography>
-                                </TableCell>
-                                <TableCell>{image.version}</TableCell>
-                                <TableCell>{image.osType}</TableCell>
-                                <TableCell>{image.architecture}</TableCell>
-                                <TableCell>{image.size}</TableCell>
-                                <TableCell>
-                                    <Chip label={getStatusText(image.status)} color={getStatusColor(image.status)} size="small" />
-                                </TableCell>
-                                <TableCell>{new Date(image.uploadDate).toLocaleString("zh-CN")}</TableCell>
-                                <TableCell>
-                                    <Tooltip title="查看详情">
-                                        <IconButton size="small">
-                                            <ViewIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Tooltip title="编辑">
-                                        <IconButton size="small" onClick={() => handleOpenDialog(image)}>
-                                            <EditIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Tooltip title="删除">
-                                        <IconButton size="small" onClick={() => handleDelete(image.id)}>
-                                            <DeleteIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                </TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </TableContainer>
+            <Box component={Paper} sx={{ boxShadow: 3 }}>
+                <DataGrid
+                    autoHeight
+                    rows={filteredImages}
+                    columns={columns}
+                    pageSizeOptions={[5, 10, 25]}
+                    paginationModel={{ pageSize: rowsPerPage, page }}
+                    onPaginationModelChange={(m) => { setRowsPerPage(m.pageSize); setPage(m.page); }}
+                    sx={{ '& .MuiDataGrid-columnHeaders': { bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[200] } }}
+                />
+            </Box>
 
             {/* 添加/编辑镜像对话框 */}
             <Dialog open={openDialog} onClose={handleCloseDialog} maxWidth="sm" fullWidth>

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -32,6 +32,7 @@ import {
     Search as SearchIcon,
 } from "@mui/icons-material"
 import { DataGrid, GridColDef } from "@mui/x-data-grid"
+import dayjs from "dayjs"
 
 interface VmImage {
     id: string
@@ -194,20 +195,8 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
     }
 
     const columns = useMemo<GridColDef[]>(() => [
-        {
-            field: 'name',
-            headerName: '镜像名称',
-            flex: 1,
-            minWidth: 180,
-            renderCell: params => (
-                <Box>
-                    <Typography variant="subtitle2">{params.row.name}</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                        {params.row.description}
-                    </Typography>
-                </Box>
-            ),
-        },
+        { field: 'name', headerName: '名称', flex: 1, minWidth: 160 },
+        { field: 'description', headerName: '描述', flex: 1, minWidth: 200 },
         { field: 'version', headerName: '版本', width: 120 },
         { field: 'osType', headerName: '操作系统', width: 120 },
         { field: 'architecture', headerName: '架构', width: 120 },
@@ -222,10 +211,10 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
         },
         {
             field: 'uploadDate',
-            headerName: '上传时间',
+            headerName: '上传日期',
             flex: 1,
             minWidth: 160,
-            valueFormatter: params => new Date(params.value as string).toLocaleString('zh-CN'),
+            valueFormatter: params => dayjs(params.value as string).format('YYYY年M月D日'),
         },
         {
             field: 'actions',

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -20,6 +20,7 @@ import {
     DialogContent,
     DialogActions,
     TextField,
+    InputAdornment,
     MenuItem,
     FormControl,
     InputLabel,
@@ -34,6 +35,7 @@ import {
     Visibility as ViewIcon,
     CloudUpload as UploadIcon,
     Computer as ComputerIcon,
+    Search as SearchIcon,
 } from "@mui/icons-material"
 
 interface VmImage {
@@ -60,7 +62,7 @@ const VmImageManagementPage: React.FC = () => {
         architecture: "x86_64" as const,
         description: "",
     })
-    const [selectedFile, setSelectedFile] = useState<File | null>(null)
+const [selectedFile, setSelectedFile] = useState<File | null>(null)
 
     // 模拟数据
     useEffect(() => {
@@ -154,6 +156,13 @@ const VmImageManagementPage: React.FC = () => {
         handleCloseDialog()
     }
 
+const [search, setSearch] = useState('')
+const filteredImages = images.filter(img =>
+    img.name.toLowerCase().includes(search.toLowerCase()) ||
+    img.version.toLowerCase().includes(search.toLowerCase()) ||
+    img.description.toLowerCase().includes(search.toLowerCase())
+)
+
     const handleDelete = (id: string) => {
         if (confirm("确定要删除这个虚拟机镜像吗？")) {
             setImages((prev) => prev.filter((img) => img.id !== id))
@@ -188,17 +197,28 @@ const VmImageManagementPage: React.FC = () => {
 
     return (
         <Box sx={{ p: 3 }}>
-            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 3 }}>
-                <Typography variant="h4" component="h1" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                    <ComputerIcon />
-                    虚拟机镜像管理
-                </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    <Typography variant="h4" component="h1">虚拟机镜像管理</Typography>
+                    <TextField
+                        variant="outlined"
+                        placeholder="搜索镜像..."
+                        onChange={(e)=>setSearch(e.target.value)}
+                        size="small"
+                        InputProps={{ startAdornment: (
+                            <InputAdornment position="start">
+                                <SearchIcon />
+                            </InputAdornment>
+                        )}}
+                        sx={{ width: { xs: '100%', sm: 260 } }}
+                    />
+                </Box>
                 <Button variant="contained" startIcon={<AddIcon />} onClick={() => handleOpenDialog()}>
                     添加镜像
                 </Button>
             </Box>
 
-            <TableContainer component={Paper}>
+            <TableContainer component={Paper} sx={{ boxShadow: 3 }}>
                 <Table>
                     <TableHead>
                         <TableRow>
@@ -213,7 +233,7 @@ const VmImageManagementPage: React.FC = () => {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {images.map((image) => (
+                        {filteredImages.map((image) => (
                             <TableRow key={image.id}>
                                 <TableCell>
                                     <Typography variant="subtitle2">{image.name}</Typography>

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -76,13 +76,13 @@ export default function VmPage() {
     /* ----- 列定义 ----- */
     const columns = React.useMemo<GridColDef[]>(() => [
         { field: "state", headerName: "", width: 40, renderCell: p => stateIcon(p.row.state) },
-        { field: "name", headerName: "Name", minWidth: 160, flex: 1 },
-        { field: "hostNode", headerName: "Node", minWidth: 120 },
-        { field: "pool", headerName: "Pool", minWidth: 120 },
+        { field: "name", headerName: "名称", minWidth: 160, flex: 1 },
+        { field: "hostNode", headerName: "宿主机", minWidth: 120 },
+        { field: "pool", headerName: "存储池", minWidth: 120 },
         { field: "vcpu", headerName: "vCPU", width: 80 },
-        { field: "vmem", headerName: "RAM (MB)", width: 100 },
+        { field: "vmem", headerName: "内存 (MB)", width: 100 },
         { field: "ip", headerName: "IP", minWidth: 140 },
-        { field: "uptime", headerName: "Uptime", minWidth: 120 },
+        { field: "uptime", headerName: "运行时间", minWidth: 120 },
     ], [])
 
     const theme = useTheme();

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -68,6 +68,8 @@ export default function VmPage() {
     const [rows] = React.useState(MOCK)
     const [current, setCurrent] = React.useState<VmInstance | null>(rows[0] ?? null)
     const [search, setSearch] = React.useState("")
+    const [page, setPage] = React.useState(0)
+    const [rowsPerPage, setRowsPerPage] = React.useState(10)
     const [tab, setTab] = React.useState(0)
     const [actionAnchor, setActionAnchor] = React.useState<null | HTMLElement>(null)
 
@@ -105,15 +107,17 @@ export default function VmPage() {
                 </Box>
             </Box>
 
-            <Box component={Paper} sx={{ boxShadow: 3 }}>
+            <Box component={Paper} sx={{ boxShadow: 3, height: '50vh', display: 'flex', flexDirection: 'column' }}>
                 <DataGrid
-                    autoHeight
                     rows={rows.filter(r => r.name.toLowerCase().includes(search.toLowerCase()))}
                     columns={columns}
                     density="compact"
-                    hideFooter
+                    pageSizeOptions={[5, 10, 25]}
+                    paginationModel={{ pageSize: rowsPerPage, page }}
+                    onPaginationModelChange={(m) => { setRowsPerPage(m.pageSize); setPage(m.page); }}
                     onRowClick={p => setCurrent(p.row)}
                     sx={{
+                        height: '100%',
                         '& .MuiDataGrid-columnHeaders': {
                             bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[200],
                         },
@@ -123,7 +127,7 @@ export default function VmPage() {
 
             {/* Details */}
             {current && (
-                <Box component={Paper} sx={{ mt: 3, p: 2, display: 'flex', flexDirection: 'column' }}>
+                <Box component={Paper} sx={{ mt: 3, p: 2, display: 'flex', flexDirection: 'column', height: '50vh', boxShadow: 3, overflow: 'auto' }}>
                     {/* Actions bar */}
                     <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
                         {stateIcon(current.state)}

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
     Box, Button, Divider, Grid, Menu, MenuItem,
     Tabs, Tab, TextField, Typography, InputAdornment,
+    Paper, useTheme,
 } from "@mui/material"
 import {
     Search as SearchIcon,
@@ -82,69 +83,66 @@ export default function VmPage() {
         { field: "uptime", headerName: "Uptime", minWidth: 120 },
     ], [])
 
+    const theme = useTheme();
     return (
-        <Box sx={{ height: "100vh", display: "flex", flexDirection: "column", overflow: "hidden" }}>
-            {/* Header */}
-            <Box sx={{ px: 2, py: 1.5, display: "flex", alignItems: "center", gap: 2 }}>
-                <ComputerIcon sx={{ color: "grey.100" }} />
-                <Typography variant="h6" sx={{ color: "grey.100" }}>
-                    VM 管理
-                </Typography>
-                <TextField
-                    size="small"
-                    placeholder="Search VM"
-                    value={search}
-                    onChange={e => setSearch(e.target.value)}
-                    InputProps={{
-                        startAdornment: (
+        <Box sx={{ p: { xs: 2, sm: 3 } }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    <Typography variant="h4" component="h1">虚拟机实例管理</Typography>
+                    <TextField
+                        variant="outlined"
+                        placeholder="搜索虚拟机..."
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                        size="small"
+                        InputProps={{ startAdornment: (
                             <InputAdornment position="start">
-                                <SearchIcon sx={{ color: "grey.500" }} />
+                                <SearchIcon />
                             </InputAdornment>
-                        ),
-                        sx: { bgcolor: "#1e1e1e", color: "white" },
-                    }}
-                    sx={{ ml: "auto", width: 260 }}
-                />
+                        )}}
+                        sx={{ width: { xs: '100%', sm: 260 } }}
+                    />
+                </Box>
             </Box>
 
-            {/* Grid */}
-            <Box sx={{ flex: 1, overflow: "hidden" }}>
+            <Box component={Paper} sx={{ boxShadow: 3 }}>
                 <DataGrid
+                    autoHeight
                     rows={rows.filter(r => r.name.toLowerCase().includes(search.toLowerCase()))}
                     columns={columns}
                     density="compact"
                     hideFooter
                     onRowClick={p => setCurrent(p.row)}
                     sx={{
-                        border: 0,
-                        "& .MuiDataGrid-columnHeaders": { bgcolor: "#111", color: "grey.300" },
-                        "& .MuiDataGrid-cell": { borderBottom: "1px solid #222", color: "grey.100" },
+                        '& .MuiDataGrid-columnHeaders': {
+                            bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[200],
+                        },
                     }}
                 />
             </Box>
 
             {/* Details */}
             {current && (
-                <Box sx={{ minHeight: "50vh", borderTop: "1px solid #333", display: "flex", flexDirection: "column" }}>
+                <Box component={Paper} sx={{ mt: 3, p: 2, display: 'flex', flexDirection: 'column' }}>
                     {/* Actions bar */}
-                    <Box sx={{ px: 2, py: 1, display: "flex", alignItems: "center", gap: 1 }}>
+                    <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
                         {stateIcon(current.state)}
-                        <Typography sx={{ color: "grey.100", mr: 2 }}>{current.name}</Typography>
+                        <Typography sx={{ mr: 2 }}>{current.name}</Typography>
 
                         {current.state === "running" ? (
                             <>
-                                <Button size="small" startIcon={<PauseIcon />} sx={{ color: "grey.200" }}>
+                                <Button size="small" startIcon={<PauseIcon />}>
                                     Pause
                                 </Button>
-                                <Button size="small" startIcon={<StopIcon />} sx={{ color: "grey.200" }}>
+                                <Button size="small" startIcon={<StopIcon />}>
                                     Shutdown
                                 </Button>
-                                <Button size="small" startIcon={<ResetIcon />} sx={{ color: "grey.200" }}>
+                                <Button size="small" startIcon={<ResetIcon />}>
                                     Reboot
                                 </Button>
                             </>
                         ) : (
-                            <Button size="small" startIcon={<StartIcon />} sx={{ color: "grey.200" }}>
+                            <Button size="small" startIcon={<StartIcon />}>
                                 Start
                             </Button>
                         )}
@@ -152,7 +150,7 @@ export default function VmPage() {
                         <Button
                             size="small"
                             variant="outlined"
-                            sx={{ color: "white", borderColor: "grey.600", ml: "auto" }}
+                            sx={{ ml: 'auto' }}
                             startIcon={<ConsoleIcon />}
                         >
                             Console
@@ -162,7 +160,6 @@ export default function VmPage() {
                             variant="outlined"
                             endIcon={<ArrowDownIcon />}
                             onClick={e => setActionAnchor(e.currentTarget)}
-                            sx={{ color: "white", borderColor: "grey.600" }}
                         >
                             More
                         </Button>
@@ -172,12 +169,7 @@ export default function VmPage() {
                     <Tabs
                         value={tab}
                         onChange={(_, v) => setTab(v)}
-                        sx={{
-                            "& .MuiTab-root": { color: "grey.500", minHeight: 36 },
-                            "& .Mui-selected": { color: "skyblue" },
-                            borderBottom: "1px solid #222",
-                            pl: 2,
-                        }}
+                        sx={{ borderBottom: 1, borderColor: 'divider', pl: 2 }}
                     >
                         {["Overview", "Snapshots", "Storage", "Network", "Performance", "Events"].map(l => (
                             <Tab key={l} label={l.toUpperCase()} />
@@ -189,10 +181,10 @@ export default function VmPage() {
                         {tab === 0 && (
                             <Grid container spacing={3}>
                                 <Grid item xs={4}>
-                                    <Typography variant="subtitle2" sx={{ color: "grey.100", mb: 1 }}>
+                                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
                                         基本信息
                                     </Typography>
-                                    <Box sx={{ color: "grey.300", fontSize: 14, display: "flex", flexDirection: "column", gap: 0.75 }}>
+                                    <Box sx={{ fontSize: 14, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
                                         <span>Host Node: {current.hostNode}</span>
                                         <span>Pool: {current.pool}</span>
                                         <span>vCPU: {current.vcpu}</span>
@@ -207,7 +199,7 @@ export default function VmPage() {
 
                         {/* 其它标签占位 */}
                         {tab !== 0 && (
-                            <Typography sx={{ color: "grey.400" }}>
+                            <Typography color="text.secondary">
                                 {["Snapshots", "Storage", "Network", "Performance", "Events"][tab - 1]} 页面待实现…
                             </Typography>
                         )}
@@ -220,13 +212,12 @@ export default function VmPage() {
                 anchorEl={actionAnchor}
                 open={Boolean(actionAnchor)}
                 onClose={() => setActionAnchor(null)}
-                PaperProps={{ sx: { bgcolor: "#2a2a2a", color: "grey.100" } }}
             >
                 <MenuItem onClick={() => setActionAnchor(null)}>
                     <SnapshotIcon fontSize="small" sx={{ mr: 1 }} />
                     创建快照
                 </MenuItem>
-                <Divider sx={{ bgcolor: "grey.700" }} />
+                <Divider />
                 <MenuItem onClick={() => setActionAnchor(null)}>
                     <VncIcon fontSize="small" sx={{ mr: 1 }} />
                     VNC / SPICE 控制台


### PR DESCRIPTION
## Summary
- match VM instance page layout with container pages
- align VM image management style with container pages

## Testing
- `npm test` *(fails: Missing script)*
- `(from src/) npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68634ec57cec8320a7dab5abb1223f9e