### PR TITLE
Add richer VM detail panels

### DIFF
--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -25,6 +25,12 @@ import {
     KeyboardArrowDown as ArrowDownIcon,
 } from "@mui/icons-material"
 import { DataGrid, GridColDef } from "@mui/x-data-grid"
+import OverviewPanel from "@/components/vm/OverviewPanel"
+import SnapshotsPanel from "@/components/vm/SnapshotsPanel"
+import StoragePanel from "@/components/vm/StoragePanel"
+import NetworkPanel from "@/components/vm/NetworkPanel"
+import PerformancePanel from "@/components/vm/PerformancePanel"
+import EventsPanel from "@/components/vm/EventsPanel"
 
 /* ---------- 类型 ---------- */
 interface VmInstance {
@@ -182,31 +188,12 @@ export default function VmPage() {
 
                     {/* Panels */}
                     <Box sx={{ flex: 1, p: 2 }}>
-                        {tab === 0 && (
-                            <Grid container spacing={3}>
-                                <Grid item xs={4}>
-                                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                                        基本信息
-                                    </Typography>
-                                    <Box sx={{ fontSize: 14, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                                        <span>Host Node: {current.hostNode}</span>
-                                        <span>Pool: {current.pool}</span>
-                                        <span>vCPU: {current.vcpu}</span>
-                                        <span>vRAM: {current.vmem} MB</span>
-                                        {current.ip && <span>IP: {current.ip}</span>}
-                                    </Box>
-                                </Grid>
-
-                                {/* 其他概览块（可填充 CPU/MEM 仪表、磁盘利用等） */}
-                            </Grid>
-                        )}
-
-                        {/* 其它标签占位 */}
-                        {tab !== 0 && (
-                            <Typography color="text.secondary">
-                                {["Snapshots", "Storage", "Network", "Performance", "Events"][tab - 1]} 页面待实现…
-                            </Typography>
-                        )}
+                        {tab === 0 && <OverviewPanel />}
+                        {tab === 1 && <SnapshotsPanel />}
+                        {tab === 2 && <StoragePanel />}
+                        {tab === 3 && <NetworkPanel />}
+                        {tab === 4 && <PerformancePanel />}
+                        {tab === 5 && <EventsPanel />}
                     </Box>
                 </Box>
             )}

--- a/src/components/vm/EventsPanel.tsx
+++ b/src/components/vm/EventsPanel.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react'
+import {
+  Box, Button, MenuItem, Select, Stack, Table, TableBody, TableCell,
+  TableHead, TableRow, TextField, Toolbar, Typography
+} from '@mui/material'
+
+const events = [
+  { time: '10:01:00', level: 'info', detail: 'VM started' },
+  { time: '10:05:10', level: 'warning', detail: 'High CPU usage' },
+  { time: '10:06:30', level: 'info', detail: 'Snapshot created' }
+]
+
+export default function EventsPanel() {
+  const [level, setLevel] = useState('all')
+
+  return (
+    <Box>
+      <Toolbar disableGutters sx={{ mb: 1 }}>
+        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+          <Select size="small" value={level} onChange={e => setLevel(e.target.value)}>
+            <MenuItem value="all">全部</MenuItem>
+            <MenuItem value="info">Info</MenuItem>
+            <MenuItem value="warning">Warning</MenuItem>
+            <MenuItem value="error">Error</MenuItem>
+          </Select>
+          <TextField size="small" placeholder="关键词" />
+          <Button size="small" variant="outlined">导出 CSV</Button>
+          <Button size="small" color="error">清空</Button>
+        </Stack>
+      </Toolbar>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Time</TableCell>
+            <TableCell>Level</TableCell>
+            <TableCell>Detail</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {events.map((e, idx) => (
+            <TableRow key={idx}>
+              <TableCell>{e.time}</TableCell>
+              <TableCell>{e.level}</TableCell>
+              <TableCell>{e.detail}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  )
+}

--- a/src/components/vm/NetworkPanel.tsx
+++ b/src/components/vm/NetworkPanel.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import {
+  Box, Button, Drawer, FormControl, IconButton, InputLabel, MenuItem,
+  Select, Table, TableBody, TableCell, TableHead, TableRow, Toolbar,
+  Typography
+} from '@mui/material'
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon
+} from '@mui/icons-material'
+
+interface Nic {
+  mac: string
+  bridge: string
+  model: string
+  pci: string
+  rx: number
+  tx: number
+}
+
+const nics: Nic[] = [
+  { mac: '52:54:00:aa:bb:cc', bridge: 'virbr0', model: 'virtio', pci: '0000:00:03.0', rx: 12, tx: 3 },
+  { mac: '52:54:00:dd:ee:ff', bridge: 'virbr1', model: 'e1000', pci: '0000:00:04.0', rx: 0, tx: 0 }
+]
+
+export default function NetworkPanel() {
+  const [drawer, setDrawer] = useState(false)
+  const [edit, setEdit] = useState<Nic | null>(null)
+
+  return (
+    <Box>
+      <Toolbar disableGutters sx={{ mb: 1 }}>
+        <Button startIcon={<AddIcon />}>Attach NIC</Button>
+      </Toolbar>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>MAC</TableCell>
+            <TableCell>Bridge</TableCell>
+            <TableCell>Model</TableCell>
+            <TableCell>PCI</TableCell>
+            <TableCell>RX (KB/s)</TableCell>
+            <TableCell>TX (KB/s)</TableCell>
+            <TableCell align="right">操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {nics.map(nic => (
+            <TableRow key={nic.mac} hover>
+              <TableCell>{nic.mac}</TableCell>
+              <TableCell>{nic.bridge}</TableCell>
+              <TableCell>{nic.model}</TableCell>
+              <TableCell>{nic.pci}</TableCell>
+              <TableCell>{nic.rx}</TableCell>
+              <TableCell>{nic.tx}</TableCell>
+              <TableCell align="right">
+                <IconButton size="small" onClick={() => { setEdit(nic); setDrawer(true) }}><EditIcon fontSize="small" /></IconButton>
+                <IconButton size="small" color="error"><DeleteIcon fontSize="small" /></IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Drawer anchor="right" open={drawer} onClose={() => setDrawer(false)} sx={{ '& .MuiDrawer-paper': { width: 280, p: 2 } }}>
+        <Typography variant="h6" gutterBottom>编辑 vNIC</Typography>
+        <FormControl fullWidth size="small" sx={{ mt: 2 }}>
+          <InputLabel>绑定网络</InputLabel>
+          <Select defaultValue={edit?.bridge || ''} label="绑定网络">
+            <MenuItem value="virbr0">virbr0</MenuItem>
+            <MenuItem value="virbr1">virbr1</MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl fullWidth size="small" sx={{ mt: 2 }}>
+          <InputLabel>模型</InputLabel>
+          <Select defaultValue={edit?.model || ''} label="模型">
+            <MenuItem value="virtio">virtio</MenuItem>
+            <MenuItem value="e1000">e1000</MenuItem>
+          </Select>
+        </FormControl>
+        <Button variant="contained" sx={{ mt: 3 }}>保存</Button>
+      </Drawer>
+    </Box>
+  )
+}

--- a/src/components/vm/OverviewPanel.tsx
+++ b/src/components/vm/OverviewPanel.tsx
@@ -51,7 +51,7 @@ export default function OverviewPanel() {
       </Stack>
 
       <Grid container spacing={3}>
-        <Grid item xs={12} md={4}>
+        <Grid item size={{ xs: 12, md: 4 }}>
           <Typography variant="subtitle2" sx={{ mb: 1 }}>基本信息</Typography>
           <Stack spacing={0.5} sx={{ fontSize: 14 }}>
             <span>Host Node: {info.hostNode}</span>
@@ -63,7 +63,7 @@ export default function OverviewPanel() {
             <span>Uptime: {info.uptime}</span>
           </Stack>
         </Grid>
-        <Grid item xs={12} md={8}>
+        <Grid item size={{ xs: 12, md: 8 }}>
           <Typography variant="subtitle2" sx={{ mb: 1 }}>实时用量</Typography>
           <Stack direction="row" spacing={3}>
             <MiniGauge label="CPU" value={usage.cpu} />

--- a/src/components/vm/OverviewPanel.tsx
+++ b/src/components/vm/OverviewPanel.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import {
+  Box, Button, CircularProgress, Grid, IconButton, Stack, Typography
+} from '@mui/material'
+import {
+  PlayArrow as StartIcon,
+  Pause as PauseIcon,
+  Stop as StopIcon,
+  RestartAlt as RebootIcon,
+  PowerSettingsNew as ForceIcon,
+  DesktopWindows as ConsoleIcon
+} from '@mui/icons-material'
+
+export default function OverviewPanel() {
+  const info = {
+    hostNode: 'kvm-node-1',
+    pool: 'default',
+    vcpu: 4,
+    vram: 8192,
+    ip: '192.168.122.101',
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    uptime: '2d 03:12'
+  }
+
+  const usage = {
+    cpu: 45,
+    mem: 70,
+    disk: 40,
+    net: 12
+  }
+
+  const MiniGauge: React.FC<{label: string; value: number}> = ({ label, value }) => (
+    <Box sx={{ textAlign: 'center' }}>
+      <CircularProgress variant="determinate" value={value} size={60} thickness={4} />
+      <Typography variant="caption" display="block" sx={{ mt: 0.5 }}>{label} {value}%</Typography>
+    </Box>
+  )
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          <StartIcon color="success" sx={{ verticalAlign: 'middle', mr: 1 }} /> demo-vm
+        </Typography>
+        <IconButton size="small" color="primary"><StartIcon /></IconButton>
+        <IconButton size="small" color="primary"><PauseIcon /></IconButton>
+        <IconButton size="small" color="primary"><StopIcon /></IconButton>
+        <IconButton size="small" color="primary"><RebootIcon /></IconButton>
+        <IconButton size="small" color="error"><ForceIcon /></IconButton>
+        <Button size="small" variant="outlined" startIcon={<ConsoleIcon />}>Console</Button>
+      </Stack>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={4}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>基本信息</Typography>
+          <Stack spacing={0.5} sx={{ fontSize: 14 }}>
+            <span>Host Node: {info.hostNode}</span>
+            <span>Pool: {info.pool}</span>
+            <span>vCPU: {info.vcpu}</span>
+            <span>vRAM: {info.vram} MB</span>
+            <span>IP: {info.ip}</span>
+            <span>UUID: {info.uuid}</span>
+            <span>Uptime: {info.uptime}</span>
+          </Stack>
+        </Grid>
+        <Grid item xs={12} md={8}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>实时用量</Typography>
+          <Stack direction="row" spacing={3}>
+            <MiniGauge label="CPU" value={usage.cpu} />
+            <MiniGauge label="Memory" value={usage.mem} />
+            <MiniGauge label="Disk" value={usage.disk} />
+            <MiniGauge label="Net" value={usage.net} />
+          </Stack>
+        </Grid>
+      </Grid>
+    </Stack>
+  )
+}

--- a/src/components/vm/PerformancePanel.tsx
+++ b/src/components/vm/PerformancePanel.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+import { Box, Button, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
+
+const charts = ['CPU 使用率', '内存 MB', '磁盘吞吐', '网络吞吐']
+
+export default function PerformancePanel() {
+  const [range, setRange] = useState('1h')
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+        <ToggleButtonGroup size="small" value={range} exclusive onChange={(_, v) => v && setRange(v)}>
+          <ToggleButton value="1h">1小时</ToggleButton>
+          <ToggleButton value="24h">24小时</ToggleButton>
+          <ToggleButton value="7d">7天</ToggleButton>
+        </ToggleButtonGroup>
+        <Button size="small" variant="outlined">导出 CSV</Button>
+      </Stack>
+      <Stack spacing={2}>
+        {charts.map(label => (
+          <Box key={label} sx={{ height: 160, bgcolor: 'grey.100', borderRadius: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography color="text.secondary">{label} 图表</Typography>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  )
+}

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -9,8 +9,8 @@ import {
   Delete as DeleteIcon,
   Restore as RestoreIcon
 } from '@mui/icons-material'
-import TreeView from '@mui/lab/TreeView'
-import TreeItem from '@mui/lab/TreeItem'
+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView'
+import { TreeItem } from '@mui/x-tree-view/TreeItem'
 
 interface Snapshot {
   id: string
@@ -41,11 +41,11 @@ export default function SnapshotsPanel() {
         </Toolbar>
       </Grid>
       <Grid item xs={4} sx={{ height: 'calc(100% - 56px)' }}>
-        <TreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}>
+        <SimpleTreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}> 
           {mock.map(s => (
             <TreeItem nodeId={s.id} key={s.id} label={`${s.name} (${s.created})`} onClick={() => setCurrent(s)} />
           ))}
-        </TreeView>
+        </SimpleTreeView>
       </Grid>
       <Grid item xs={8}>
         {current && (

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import {
   Box, Button, Card, CardContent, Dialog, DialogActions,
-  DialogContent, DialogTitle, Grid, IconButton, Stack, TextField,
+  DialogContent, DialogTitle, Grid, Stack, TextField,
   Toolbar, Typography
 } from '@mui/material'
 import {
@@ -9,7 +9,7 @@ import {
   Delete as DeleteIcon,
   Restore as RestoreIcon
 } from '@mui/icons-material'
-import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView'
+import { TreeView } from '@mui/x-tree-view'
 import { TreeItem } from '@mui/x-tree-view/TreeItem'
 
 interface Snapshot {
@@ -41,11 +41,11 @@ export default function SnapshotsPanel() {
         </Toolbar>
       </Grid>
       <Grid item xs={4} sx={{ height: 'calc(100% - 56px)' }}>
-        <SimpleTreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}> 
+        <TreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}> 
           {mock.map(s => (
             <TreeItem itemId={s.id} key={s.id} label={`${s.name} (${s.created})`} onClick={() => setCurrent(s)} />
           ))}
-        </SimpleTreeView>
+        </TreeView>
       </Grid>
       <Grid item xs={8}>
         {current && (

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -43,7 +43,7 @@ export default function SnapshotsPanel() {
       <Grid item xs={4} sx={{ height: 'calc(100% - 56px)' }}>
         <SimpleTreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}> 
           {mock.map(s => (
-            <TreeItem nodeId={s.id} key={s.id} label={`${s.name} (${s.created})`} onClick={() => setCurrent(s)} />
+            <TreeItem itemId={s.id} key={s.id} label={`${s.name} (${s.created})`} onClick={() => setCurrent(s)} />
           ))}
         </SimpleTreeView>
       </Grid>

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -9,8 +9,7 @@ import {
   Delete as DeleteIcon,
   Restore as RestoreIcon
 } from '@mui/icons-material'
-import { TreeView } from '@mui/x-tree-view'
-import { TreeItem } from '@mui/x-tree-view/TreeItem'
+import { SimpleTreeView, TreeItem } from '@mui/x-tree-view'
 
 interface Snapshot {
   id: string
@@ -41,11 +40,11 @@ export default function SnapshotsPanel() {
         </Toolbar>
       </Grid>
       <Grid item xs={4} sx={{ height: 'calc(100% - 56px)' }}>
-        <TreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}> 
+        <SimpleTreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}>
           {mock.map(s => (
             <TreeItem itemId={s.id} key={s.id} label={`${s.name} (${s.created})`} onClick={() => setCurrent(s)} />
           ))}
-        </TreeView>
+        </SimpleTreeView>
       </Grid>
       <Grid item xs={8}>
         {current && (

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+import {
+  Box, Button, Card, CardContent, Dialog, DialogActions,
+  DialogContent, DialogTitle, Grid, IconButton, Stack, TextField,
+  Toolbar, Typography
+} from '@mui/material'
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Restore as RestoreIcon
+} from '@mui/icons-material'
+import TreeView from '@mui/lab/TreeView'
+import TreeItem from '@mui/lab/TreeItem'
+
+interface Snapshot {
+  id: string
+  name: string
+  created: string
+  parent?: string
+  size: string
+  xml: string
+}
+
+const mock: Snapshot[] = [
+  { id: '1', name: 'base', created: '2024-06-01', size: '500MB', xml: '<snap/>' },
+  { id: '2', name: 'update', created: '2024-06-05', parent: '1', size: '200MB', xml: '<snap/>' },
+  { id: '3', name: 'test', created: '2024-06-10', parent: '2', size: '150MB', xml: '<snap/>' }
+]
+
+export default function SnapshotsPanel() {
+  const [open, setOpen] = useState(false)
+  const [current, setCurrent] = useState<Snapshot | null>(mock[0])
+
+  return (
+    <Grid container spacing={2} sx={{ height: '100%' }}>
+      <Grid item xs={12}>
+        <Toolbar disableGutters sx={{ mb: 1 }}>
+          <Button startIcon={<AddIcon />} onClick={() => setOpen(true)}>创建快照</Button>
+          <Button startIcon={<RestoreIcon />} disabled sx={{ ml: 2 }}>还原</Button>
+          <Button startIcon={<DeleteIcon />} disabled sx={{ ml: 2 }}>删除</Button>
+        </Toolbar>
+      </Grid>
+      <Grid item xs={4} sx={{ height: 'calc(100% - 56px)' }}>
+        <TreeView defaultCollapseIcon={<RestoreIcon />} defaultExpandIcon={<RestoreIcon />}>
+          {mock.map(s => (
+            <TreeItem nodeId={s.id} key={s.id} label={`${s.name} (${s.created})`} onClick={() => setCurrent(s)} />
+          ))}
+        </TreeView>
+      </Grid>
+      <Grid item xs={8}>
+        {current && (
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="subtitle2" gutterBottom>{current.name}</Typography>
+              <Stack spacing={0.5} sx={{ fontSize: 14 }}>
+                <span>创建时间: {current.created}</span>
+                <span>父级: {current.parent ?? '-'}</span>
+                <span>大小: {current.size}</span>
+              </Stack>
+              <Box sx={{ mt: 2, fontSize: 12, bgcolor: 'grey.100', p: 1, borderRadius: 1 }}>
+                <pre style={{ margin: 0 }}>{current.xml}</pre>
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+      </Grid>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>创建快照</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="名称" fullWidth size="small" />
+          <TextField label="描述" fullWidth size="small" multiline rows={3} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>取消</Button>
+          <Button variant="contained">确定</Button>
+        </DialogActions>
+      </Dialog>
+    </Grid>
+  )
+}

--- a/src/components/vm/StoragePanel.tsx
+++ b/src/components/vm/StoragePanel.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import {
+  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle,
+  Grid, IconButton, LinearProgress, Paper, Table, TableBody,
+  TableCell, TableHead, TableRow, TextField, Toolbar, Typography
+} from '@mui/material'
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Expand as ExpandIcon
+} from '@mui/icons-material'
+
+interface Disk {
+  target: string
+  source: string
+  format: string
+  size: number
+  alloc: number
+}
+
+const disks: Disk[] = [
+  { target: 'vda', source: '/var/lib/libvirt/images/disk1.qcow2', format: 'qcow2', size: 20, alloc: 8 },
+  { target: 'vdb', source: '/var/lib/libvirt/images/disk2.qcow2', format: 'qcow2', size: 40, alloc: 30 }
+]
+
+export default function StoragePanel() {
+  const [addOpen, setAddOpen] = useState(false)
+
+  return (
+    <Box>
+      <Toolbar disableGutters sx={{ mb: 1 }}>
+        <Button startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>新增磁盘</Button>
+      </Toolbar>
+      <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Target</TableCell>
+              <TableCell>Source</TableCell>
+              <TableCell>Format</TableCell>
+              <TableCell>Capacity</TableCell>
+              <TableCell>Allocated</TableCell>
+              <TableCell>Usage</TableCell>
+              <TableCell align="right">操作</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {disks.map(d => (
+              <TableRow key={d.target} hover>
+                <TableCell>{d.target}</TableCell>
+                <TableCell>{d.source}</TableCell>
+                <TableCell>{d.format}</TableCell>
+                <TableCell>{d.size}G</TableCell>
+                <TableCell>{d.alloc}G</TableCell>
+                <TableCell sx={{ minWidth: 120 }}>
+                  <LinearProgress variant="determinate" value={d.alloc / d.size * 100} />
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton size="small"><ExpandIcon fontSize="small" /></IconButton>
+                  <IconButton size="small" color="error"><DeleteIcon fontSize="small" /></IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <Dialog open={addOpen} onClose={() => setAddOpen(false)}>
+        <DialogTitle>新增磁盘</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="存储池" fullWidth size="small" />
+          <TextField label="容量 (GB)" type="number" fullWidth size="small" />
+          <TextField label="总线类型" fullWidth size="small" />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddOpen(false)}>取消</Button>
+          <Button variant="contained">确定</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- rewrite VM detail panel components using various MUI widgets
- add gauges and action buttons on Overview panel
- implement snapshot tree with creation dialog
- add dialogs and progress bars for storage management
- add drawer-based NIC editor and attach button
- add performance range switcher and event log filters

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module declarations and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68636de611f48320bf1d365f66bd00e5