### PR TITLE
Integrate libvirt backend data

### DIFF
--- a/back/app/Services/DockerService.php
+++ b/back/app/Services/DockerService.php
@@ -22,8 +22,10 @@ class DockerService
     {
 
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            logger()->debug("windows dockerd detect");
             $socket = getenv('DOCKER_HOST') ?: 'tcp://localhost:2375';
         } else {
+            logger()->debug("linux dockerd detect");
             $socket = getenv('DOCKER_HOST') ?: 'unix:///var/run/docker.sock';
         }
         $client = DockerClientFactory::create(['remote_socket' => $socket]);

--- a/src/app/scenario/images/page.tsx
+++ b/src/app/scenario/images/page.tsx
@@ -36,7 +36,7 @@ import ImageFormModal from '@/components/imagemanagement/ImageFormModal';
 import CreateContainerModal from '@/components/scenario/CreateContainerModal';
 import { useAuth } from '@/hooks/useAuth';
 import dayjs from 'dayjs';
-const API_BASE = "http://localhost:8000";
+const API_BASE = '/api/php';
 
 const ImageManagementPage: React.FC = () => {
   const { user } = useAuth();

--- a/src/app/scenario/instances/page.tsx
+++ b/src/app/scenario/instances/page.tsx
@@ -20,7 +20,7 @@ import {
     MenuItem,
 } from '@mui/material';
 
-const API_BASE = "http://localhost:8000";
+const API_BASE = '/api/php';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import RefreshIcon from '@mui/icons-material/Refresh';

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -60,47 +60,12 @@ const VmImageManagementPage: React.FC = () => {
     })
 const [selectedFile, setSelectedFile] = useState<File | null>(null)
 
-    // 模拟数据
+    // 从后端获取镜像列表
     useEffect(() => {
-        const mockImages: VmImage[] = [
-            {
-                id: "1",
-                name: "Ubuntu Server",
-                version: "22.04 LTS",
-                osType: "Linux",
-                architecture: "x86_64",
-                size: "2.1 GB",
-                description: "Ubuntu Server 22.04 LTS with basic tools",
-                uploadDate: "2024-01-15T10:30:00Z",
-                status: "available",
-                filePath: "/images/ubuntu-22.04.qcow2",
-            },
-            {
-                id: "2",
-                name: "Windows Server",
-                version: "2022",
-                osType: "Windows",
-                architecture: "x86_64",
-                size: "4.8 GB",
-                description: "Windows Server 2022 Standard Edition",
-                uploadDate: "2024-01-10T14:20:00Z",
-                status: "available",
-                filePath: "/images/windows-server-2022.qcow2",
-            },
-            {
-                id: "3",
-                name: "Kali Linux",
-                version: "2024.1",
-                osType: "Linux",
-                architecture: "x86_64",
-                size: "3.2 GB",
-                description: "Kali Linux penetration testing distribution",
-                uploadDate: "2024-01-20T09:15:00Z",
-                status: "available",
-                filePath: "/images/kali-2024.1.qcow2",
-            },
-        ]
-        setImages(mockImages)
+        fetch('/api/vm/images')
+            .then(res => res.json())
+            .then((data: VmImage[]) => setImages(data))
+            .catch(() => {})
     }, [])
 
     const handleOpenDialog = (image?: VmImage) => {

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -41,21 +41,7 @@ interface VmInstance {
     uptime?: string
 }
 
-/* ---------- MOCK ---------- */
-const MOCK: VmInstance[] = [
-    {
-        id: "101",
-        name: "db-01",
-        hostNode: "kvm-node-1",
-        pool: "default",
-        state: "running",
-        vcpu: 4,
-        vmem: 8192,
-        ip: "192.168.122.101",
-        uptime: "2d 03:12",
-    },
-    { id: "102", name: "web-02", hostNode: "kvm-node-2", pool: "web", state: "shutoff", vcpu: 2, vmem: 4096 },
-]
+/* ---------- 从后端获取虚拟机实例列表 ---------- */
 
 /* ---------- 状态图标 ---------- */
 function stateIcon(state: VmInstance["state"]) {
@@ -67,13 +53,24 @@ function stateIcon(state: VmInstance["state"]) {
 }
 
 export default function VmPage() {
-    const [rows] = React.useState(MOCK)
-    const [current, setCurrent] = React.useState<VmInstance | null>(rows[0] ?? null)
+    const [rows, setRows] = React.useState<VmInstance[]>([])
+    const [current, setCurrent] = React.useState<VmInstance | null>(null)
     const [search, setSearch] = React.useState("")
     const [page, setPage] = React.useState(0)
     const [rowsPerPage, setRowsPerPage] = React.useState(10)
     const [tab, setTab] = React.useState(0)
     const [actionAnchor, setActionAnchor] = React.useState<null | HTMLElement>(null)
+
+    // 从后端获取虚拟机实例列表
+    React.useEffect(() => {
+        fetch('/api/vm/instances')
+            .then(res => res.json())
+            .then((data: VmInstance[]) => {
+                setRows(data)
+                setCurrent(data[0] ?? null)
+            })
+            .catch(() => {})
+    }, [])
 
     /* ----- 列定义 ----- */
     const columns = React.useMemo<GridColDef[]>(() => [
@@ -184,12 +181,12 @@ export default function VmPage() {
 
                     {/* Panels */}
                     <Box sx={{ flex: 1, p: 2 }}>
-                        {tab === 0 && <OverviewPanel />}
-                        {tab === 1 && <SnapshotsPanel />}
-                        {tab === 2 && <StoragePanel />}
-                        {tab === 3 && <NetworkPanel />}
-                        {tab === 4 && <PerformancePanel />}
-                        {tab === 5 && <EventsPanel />}
+                        {tab === 0 && current && <OverviewPanel vmId={current.id} />}
+                        {tab === 1 && current && <SnapshotsPanel vmId={current.id} />}
+                        {tab === 2 && current && <StoragePanel vmId={current.id} />}
+                        {tab === 3 && current && <NetworkPanel vmId={current.id} />}
+                        {tab === 4 && current && <PerformancePanel vmId={current.id} />}
+                        {tab === 5 && current && <EventsPanel vmId={current.id} />}
                     </Box>
                 </Box>
             )}

--- a/src/components/scenario/BindMountsModal.tsx
+++ b/src/components/scenario/BindMountsModal.tsx
@@ -23,7 +23,7 @@ const BindMountsModal: React.FC<BindMountsModalProps> = ({ open, containerId, on
     useEffect(() => {
         if (open && containerId) {
             setLoading(true);
-            fetch(`/api/containers/${containerId}?action=binds`)
+            fetch(`/api/php/containers/${containerId}?action=binds`)
                 .then(res => res.json())
                 .then(setMounts)
                 .finally(() => setLoading(false));

--- a/src/components/scenario/ContainerInspectModal.tsx
+++ b/src/components/scenario/ContainerInspectModal.tsx
@@ -9,7 +9,7 @@ const Transition = React.forwardRef(function Transition(
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const API_BASE = "http://localhost:8000";
+const API_BASE = '/api/php';
 
 interface ContainerInspectModalProps {
   open: boolean;

--- a/src/components/scenario/ContainerLogsModal.tsx
+++ b/src/components/scenario/ContainerLogsModal.tsx
@@ -23,7 +23,7 @@ const ContainerLogsModal: React.FC<ContainerLogsModalProps> = ({ open, container
     useEffect(() => {
         if (open && containerId) {
             setLoading(true);
-            fetch(`/api/containers/${containerId}?action=logs`)
+            fetch(`/api/php/containers/${containerId}?action=logs`)
                 .then(res => res.json())
                 .then(data => setLogs(data.logs || ''))
                 .finally(() => setLoading(false));

--- a/src/components/scenario/CreateContainerModal.tsx
+++ b/src/components/scenario/CreateContainerModal.tsx
@@ -21,7 +21,7 @@ import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import { ManagedImage } from '@/types';
 import { useAuth } from '@/hooks/useAuth';
 
-const API_BASE = "http://localhost:8000";
+const API_BASE = '/api/php';
 
 interface CreateContainerModalProps {
   open: boolean;

--- a/src/components/vm/EventsPanel.tsx
+++ b/src/components/vm/EventsPanel.tsx
@@ -18,7 +18,10 @@ import {
   // SensorsOutlined as LiveTailIconOn // Placeholder for live tail
 } from '@mui/icons-material';
 
-const VM_ID = "test-vm"; // Placeholder VM ID
+
+interface EventsPanelProps {
+  vmId: string;
+}
 
 type EventLevel = 'info' | 'warning' | 'error' | 'debug';
 
@@ -39,7 +42,7 @@ const timeWindowOptions = [
 ];
 
 
-export default function EventsPanel() {
+export default function EventsPanel({ vmId }: EventsPanelProps) {
   const [events, setEvents] = useState<EventLog[]>([]);
   const [filterLevel, setFilterLevel] = useState<EventLevel | 'all'>('all');
   const [filterKeyword, setFilterKeyword] = useState('');
@@ -62,7 +65,7 @@ export default function EventsPanel() {
     // queryParams.append('limit', '200'); // Example limit
 
     try {
-      const response = await fetch(`/api/vm/${VM_ID}/events?${queryParams.toString()}`);
+        const response = await fetch(`/api/vm/${vmId}/events?${queryParams.toString()}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch events: ${response.status} ${response.statusText}`);
       }

--- a/src/components/vm/NetworkPanel.tsx
+++ b/src/components/vm/NetworkPanel.tsx
@@ -22,7 +22,10 @@ import {
   ReportProblemOutlined as EmptyIcon
 } from '@mui/icons-material';
 
-const VM_ID = "test-vm"; // Placeholder VM ID
+
+interface NetworkPanelProps {
+  vmId: string;
+}
 
 type NicModelType = 'virtio' | 'e1000' | 'rtl8139'; // Keep in sync with backend/frontend
 type NicStatusType = 'active' | 'inactive' | 'unplugged';
@@ -52,7 +55,7 @@ interface NicFormData {
 const mockBridges = ['virbr0', 'br-lan', 'host-only-net']; // Could be fetched from API
 const mockNicModels: NicModelType[] = ['virtio', 'e1000', 'rtl8139'];
 
-export default function NetworkPanel() {
+export default function NetworkPanel({ vmId }: NetworkPanelProps) {
   const [vnics, setVnics] = useState<VirtualNic[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -73,7 +76,7 @@ export default function NetworkPanel() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch(`/api/vm/${VM_ID}/network/vnics`);
+      const response = await fetch(`/api/vm/${vmId}/network/vnics`);
       if (!response.ok) throw new Error(`Failed to fetch vNICs: ${response.status}`);
       const data: VirtualNic[] = await response.json();
       setVnics(data);
@@ -128,7 +131,7 @@ export default function NetworkPanel() {
         bandwidth_limit_mbps: editingNicData.bandwidth_limit_mbps,
         vlan_tag: editingNicData.vlan_tag,
     };
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/network/vnics/${editingNic.id}`, 'PUT', payload, () => {
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/network/vnics/${editingNic.id}`, 'PUT', payload, () => {
       setEditDrawerOpen(false);
       setEditingNic(null);
     });
@@ -144,14 +147,14 @@ export default function NetworkPanel() {
         setError("Bridge and Model are required for a new NIC.");
         return;
     }
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/network/vnics`, 'POST', newNicData, () => {
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/network/vnics`, 'POST', newNicData, () => {
       setAttachDrawerOpen(false);
     });
   };
 
   const handleDeleteNic = (nicId: string, nicMac?: string) => {
     if (!window.confirm(`Are you sure you want to delete vNIC ${nicMac || nicId}?`)) return;
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/network/vnics/${nicId}`, 'DELETE');
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/network/vnics/${nicId}`, 'DELETE');
   };
 
   const renderRateChip = (rateKbps: number, type: 'rx' | 'tx') => {

--- a/src/components/vm/OverviewPanel.tsx
+++ b/src/components/vm/OverviewPanel.tsx
@@ -6,7 +6,10 @@ import {
   Dns, Memory as MemoryIconMui, Storage as StorageIcon, NetworkCheck
 } from '@mui/icons-material'; // Renamed Memory to MemoryIconMui to avoid conflict
 
-const VM_ID = "test-vm"; // Placeholder VM ID
+
+interface OverviewPanelProps {
+  vmId: string;
+}
 
 interface VCPUInfo {
   count: number;
@@ -52,7 +55,7 @@ const KeyValueListItem: React.FC<{label: string; value: string | number | undefi
   </Stack>
 );
 
-export default function OverviewPanel() {
+export default function OverviewPanel({ vmId }: OverviewPanelProps) {
   const [overviewData, setOverviewData] = useState<OverviewData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -62,7 +65,7 @@ export default function OverviewPanel() {
       setIsLoading(true);
       setError(null);
       try {
-        const response = await fetch(`/api/vm/${VM_ID}/overview`);
+        const response = await fetch(`/api/vm/${vmId}/overview`);
         if (!response.ok) {
           throw new Error(`Failed to fetch overview data: ${response.status} ${response.statusText}`);
         }

--- a/src/components/vm/PerformancePanel.tsx
+++ b/src/components/vm/PerformancePanel.tsx
@@ -55,9 +55,11 @@ interface HistoricalMetrics {
   network_throughput_mbps_total: MetricDataPoint[];
 }
 
-const VM_ID = "test-vm"; // Placeholder VM ID
+interface PerformancePanelProps {
+  vmId: string;
+}
 
-export default function PerformancePanel() {
+export default function PerformancePanel({ vmId }: PerformancePanelProps) {
   const [timeRange, setTimeRange] = useState(timeRanges[0].value);
   const [refreshIntervalValue, setRefreshIntervalValue] = useState(refreshIntervals[1].value); // Renamed to avoid conflict
   const [performanceData, setPerformanceData] = useState<HistoricalMetrics | null>(null);
@@ -68,7 +70,7 @@ export default function PerformancePanel() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch(`/api/vm/${VM_ID}/performance/historical?range=${currentRange}`);
+      const response = await fetch(`/api/vm/${vmId}/performance/historical?range=${currentRange}`);
       if (!response.ok) {
         const errBody = await response.text();
         throw new Error(`Failed to fetch performance data: ${response.status} ${response.statusText} - ${errBody}`);
@@ -81,7 +83,7 @@ export default function PerformancePanel() {
     } finally {
       setIsLoading(false);
     }
-  }, []); // VM_ID can be added if it's dynamic
+  }, [vmId]);
 
   useEffect(() => {
     fetchPerformanceData(timeRange);

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -19,8 +19,9 @@ import {
 } from '@mui/icons-material';
 import { SimpleTreeView, TreeItem, TreeViewBasePayload } from '@mui/x-tree-view'; // Added TreeViewBasePayload
 
-const VM_ID = "test-vm"; // Placeholder VM ID
-
+interface SnapshotsPanelProps {
+  vmId: string;
+}
 
 interface Snapshot {
   id: string;
@@ -32,7 +33,7 @@ interface Snapshot {
   xml?: string;
 }
 
-export default function SnapshotsPanel() {
+export default function SnapshotsPanel({ vmId }: SnapshotsPanelProps) {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -48,7 +49,7 @@ export default function SnapshotsPanel() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch(`${API_BASE_URL}/vm/${VM_ID}/snapshots`);
+      const response = await fetch(`${API_BASE_URL}/vm/${vmId}/snapshots`);
       if (!response.ok) {
         throw new Error(`Failed to fetch snapshots: ${response.status} ${response.statusText}`);
       }
@@ -86,7 +87,7 @@ export default function SnapshotsPanel() {
     setActionInProgress(true);
     setError(null);
     try {
-      const response = await fetch(`/api/vm/${VM_ID}/snapshots`, {
+      const response = await fetch(`/api/vm/${vmId}/snapshots`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: newSnapshotName, description: newSnapshotDescription }),
@@ -118,7 +119,7 @@ export default function SnapshotsPanel() {
         return;
     }
     try {
-      const response = await fetch(`${API_BASE_URL}/vm/${VM_ID}/snapshots/${selectedSnapshotId}`, {
+      const response = await fetch(`${API_BASE_URL}/vm/${vmId}/snapshots/${selectedSnapshotId}`, {
         method: 'DELETE',
       });
       if (!response.ok && response.status !== 204) { // 204 is also a success (No Content)
@@ -143,7 +144,7 @@ export default function SnapshotsPanel() {
         return;
     }
     try {
-      const response = await fetch(`${API_BASE_URL}/vm/${VM_ID}/snapshots/${selectedSnapshot.id}/revert`, {
+      const response = await fetch(`${API_BASE_URL}/vm/${vmId}/snapshots/${selectedSnapshot.id}/revert`, {
         method: 'POST',
       });
       if (!response.ok) {

--- a/src/components/vm/StoragePanel.tsx
+++ b/src/components/vm/StoragePanel.tsx
@@ -18,7 +18,10 @@ import {
   ReportProblemOutlined as EmptyIcon
 } from '@mui/icons-material';
 
-const VM_ID = "test-vm"; // Placeholder VM ID
+
+interface StoragePanelProps {
+  vmId: string;
+}
 
 interface Disk {
   id: string;
@@ -45,7 +48,7 @@ const mockBusTypes: Disk['bus'][] = ['virtio', 'sata', 'scsi', 'ide'];
 const mockIsoImages = ['/isos/ubuntu-22.04.iso', '/isos/centos-stream-9.iso', '/isos/windows-11.iso'];
 
 
-export default function StoragePanel() {
+export default function StoragePanel({ vmId }: StoragePanelProps) {
   const [disks, setDisks] = useState<Disk[]>([]);
   const [cdRoms, setCdRoms] = useState<CdRomDevice[]>([]);
 
@@ -69,7 +72,7 @@ export default function StoragePanel() {
     setIsLoadingDisks(true);
     setError(null);
     try {
-      const response = await fetch(`${API_BASE_URL}/vm/${VM_ID}/storage/disks`);
+      const response = await fetch(`${API_BASE_URL}/vm/${vmId}/storage/disks`);
       if (!response.ok) throw new Error(`Failed to fetch disks: ${response.status}`);
       const data: Disk[] = await response.json();
       setDisks(data);
@@ -81,7 +84,7 @@ export default function StoragePanel() {
     setIsLoadingCdRoms(true);
     setError(null);
     try {
-      const response = await fetch(`/api/vm/${VM_ID}/storage/cdroms`);
+      const response = await fetch(`/api/vm/${vmId}/storage/cdroms`);
       if (!response.ok) throw new Error(`Failed to fetch CD-ROMs: ${response.status}`);
       const data: CdRomDevice[] = await response.json();
       setCdRoms(data);
@@ -124,7 +127,7 @@ export default function StoragePanel() {
       setError('Invalid capacity for new disk.');
       return;
     }
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/storage/disks`, 'POST', { ...newDisk, capacity_gb: capacityNum }, () => {
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/storage/disks`, 'POST', { ...newDisk, capacity_gb: capacityNum }, () => {
       setAddDiskOpen(false);
       setNewDisk({ pool_name: mockStoragePools[0], capacity_gb: '20', bus: 'virtio', format: 'qcow2' });
     });
@@ -132,7 +135,7 @@ export default function StoragePanel() {
 
   const handleDeleteDisk = (diskId: string) => {
     if (!window.confirm(`Are you sure you want to delete disk ${disks.find(d=>d.id === diskId)?.target || diskId}?`)) return;
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/storage/disks/${diskId}`, 'DELETE');
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/storage/disks/${diskId}`, 'DELETE');
   };
 
   const openResizeDialog = (disk: Disk) => {
@@ -148,7 +151,7 @@ export default function StoragePanel() {
       setError('New size must be larger than current capacity.');
       return;
     }
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/storage/disks/${diskToResize.id}/resize`, 'POST', { new_capacity_gb: sizeNum }, () => {
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/storage/disks/${diskToResize.id}/resize`, 'POST', { new_capacity_gb: sizeNum }, () => {
       setResizeDiskOpen(false);
       setDiskToResize(null);
     });
@@ -162,13 +165,13 @@ export default function StoragePanel() {
 
   const handleMountIso = () => {
     if (!cdRomToMount) return;
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/storage/cdroms/${cdRomToMount.id}/mount`, 'POST', { iso_path: selectedIsoPath }, () => {
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/storage/cdroms/${cdRomToMount.id}/mount`, 'POST', { iso_path: selectedIsoPath }, () => {
       setMountIsoOpen(false);
     });
   };
 
   const handleEjectIso = (cdRomId: string) => {
-    handleApiCall(`${API_BASE_URL}/vm/${VM_ID}/storage/cdroms/${cdRomId}/eject`, 'POST');
+    handleApiCall(`${API_BASE_URL}/vm/${vmId}/storage/cdroms/${cdRomId}/eject`, 'POST');
   };
 
   const renderDiskRows = () => {

--- a/src/main.py
+++ b/src/main.py
@@ -129,6 +129,25 @@ class Snapshot(SnapshotBase):
     size_mb: int = Field(..., example=1024) # Simplified size
     xml: Optional[str] = Field(None, example="<domainsnapshot>...</domainsnapshot>")
 
+# 新增：虚拟机实例和镜像的模型，用于从 libvirt 获取真实数据
+class VmInstance(BaseModel):
+    id: str
+    name: str
+    hostNode: str
+    pool: str
+    state: str
+    vcpu: int
+    vmem: int
+    ip: Optional[str] = None
+    uptime: Optional[str] = None
+
+class VmImage(BaseModel):
+    id: str
+    name: str
+    pool: str
+    size: str
+    path: str
+
 
 # --- Mock Data Store ---
 # Using global variables for mock data for simplicity in this example.
@@ -178,6 +197,65 @@ def init_mock_snapshots():
 
 init_mock_snapshots()
 
+# --- Libvirt 数据获取工具函数 ---
+def fetch_vm_instances() -> List[VmInstance]:
+    """从 libvirt 获取虚拟机实例列表。如果连接不可用则返回空列表。"""
+    instances: List[VmInstance] = []
+    if not LIBVIRT_CONNECTION:
+        return instances
+    try:
+        host_node = LIBVIRT_CONNECTION.getHostname()
+        for dom in LIBVIRT_CONNECTION.listAllDomains():
+            state, _ = dom.state()
+            # 状态码转换为字符串，便于前端显示
+            if state == libvirt.VIR_DOMAIN_RUNNING:
+                state_str = "running"
+            elif state == libvirt.VIR_DOMAIN_PAUSED:
+                state_str = "paused"
+            else:
+                state_str = "shutoff"
+
+            info = dom.info()
+            instance = VmInstance(
+                id=str(dom.ID()),
+                name=dom.name(),
+                hostNode=host_node,
+                pool="default",
+                state=state_str,
+                vcpu=info[3],
+                vmem=int(info[1] / 1024),
+            )
+            instances.append(instance)
+    except libvirt.libvirtError:
+        pass
+    return instances
+
+
+def fetch_vm_images() -> List[VmImage]:
+    """从 libvirt 所有存储池获取镜像卷信息。"""
+    images: List[VmImage] = []
+    if not LIBVIRT_CONNECTION:
+        return images
+    try:
+        for pool in LIBVIRT_CONNECTION.listAllStoragePools():
+            pool.refresh(0)
+            for vol_name in pool.listVolumes():
+                vol = pool.storageVolLookupByName(vol_name)
+                info = vol.info()
+                size_gb = info[1] / (1024 ** 3)
+                images.append(
+                    VmImage(
+                        id=vol_name,
+                        name=vol_name,
+                        pool=pool.name(),
+                        size=f"{size_gb:.1f} GB",
+                        path=vol.path(),
+                    )
+                )
+    except libvirt.libvirtError:
+        pass
+    return images
+
 
 # --- API Endpoints ---
 
@@ -216,6 +294,19 @@ async def get_vm_overview(vm_id: str):
             pass # Ignore parsing errors for mock uptime
 
     return mock_vm_overview
+
+
+# 读取虚拟机实例和镜像列表的接口
+@app.get("/api/vm/instances", response_model=List[VmInstance], tags=["Instances"])
+async def api_vm_instances():
+    """返回所有虚拟机实例信息"""
+    return fetch_vm_instances()
+
+
+@app.get("/api/vm/images", response_model=List[VmImage], tags=["Images"])
+async def api_vm_images():
+    """返回所有存储卷(镜像)信息"""
+    return fetch_vm_images()
 
 # Lifecycle actions
 @app.post("/api/vm/{vm_id}/overview/{action}", response_model=LifecycleActionResponse, tags=["Overview"])

--- a/src/main.py
+++ b/src/main.py
@@ -1,92 +1,52 @@
 from fastapi import FastAPI, HTTPException, Path, Body
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
+from datetime import datetime
 from uuid import uuid4
-from datetime import datetime, timedelta
-import random
-import platform
 import os
-import libvirt # Uncomment when libvirt is actually used and installed
-from enum import Enum # Added for EventLogLevel
-from contextlib import asynccontextmanager # Added for lifespan manager
+import libvirt
+from contextlib import asynccontextmanager
 
-# --- Libvirt Connection Framework ---
+# ---------------- Libvirt Connection ----------------
 LIBVIRT_CONNECTION = None
 
 def get_libvirt_connection():
-    conn = None
-    uri = "qemu:///system" # Assuming development is now directly within WSL or a Linux environment
-
-    print(f"Attempting local libvirt connection (WSL/Linux): {uri}")
+    """建立到 libvirt 的连接"""
     try:
-        conn = libvirt.open(uri)
+        return libvirt.open("qemu:///system")
     except libvirt.libvirtError as e:
-        print(f"Failed to connect to local libvirt ({uri}): {e}")
-        print("Ensure libvirtd service is active and configured in your WSL/Linux environment.")
-        conn = None
-
-    if conn is None:
-        print("Failed to establish libvirt connection. API will use mock data or operate in a limited mode.")
-    else:
-        print("Successfully connected to libvirt service.")
-    return conn
+        print(f"libvirt 连接失败: {e}")
+        return None
 
 @asynccontextmanager
-async def lifespan(app_instance: FastAPI): # app_instance is the FastAPI app
+async def lifespan(app: FastAPI):
     global LIBVIRT_CONNECTION
-    print("FastAPI application starting up (lifespan). Attempting to initialize libvirt connection...")
     LIBVIRT_CONNECTION = get_libvirt_connection()
+    yield
     if LIBVIRT_CONNECTION:
-        try:
-            hostname = LIBVIRT_CONNECTION.getHostname()
-            print(f"Libvirt connection successful (lifespan). Hostname: {hostname}")
-        except Exception as e:
-            print(f"Libvirt connection established but failed to get hostname (lifespan): {e}")
-            LIBVIRT_CONNECTION = None
-            print("Reverted to no Libvirt connection due to post-connection check failure (lifespan).")
-    else:
-        print("Libvirt connection failed during startup (lifespan). Backend will use mock data.")
-        print("Ensure libvirt service is running and configured correctly.")
-        print("- On Linux/WSL: Check 'sudo systemctl status libvirtd' or 'sudo service libvirtd status'.")
-        print("- On Windows (for WSL connection): Set WSL_LIBVIRT_IP and ensure WSL's libvirtd listens on TCP.")
-
-    yield # Application runs here
-
-    # Shutdown logic
-    if LIBVIRT_CONNECTION:
-        print("FastAPI application shutting down (lifespan). Closing libvirt connection...")
-        try:
-            LIBVIRT_CONNECTION.close()
-            print("Libvirt connection closed (lifespan).")
-        except Exception as e:
-            print(f"Error closing libvirt connection (lifespan): {e}")
+        LIBVIRT_CONNECTION.close()
         LIBVIRT_CONNECTION = None
 
-# --- End Libvirt Connection Framework ---
+app = FastAPI(title="VM Management API", lifespan=lifespan)
 
+# ---------------- Pydantic Models ----------------
+class VmInstance(BaseModel):
+    id: str
+    name: str
+    hostNode: str
+    pool: str
+    state: str
+    vcpu: int
+    vmem: int
+    ip: Optional[str] = None
 
-app = FastAPI(
-    title="VM Management API",
-    description="API for managing virtual machines (mock implementation)",
-    version="0.1.0",
-    lifespan=lifespan # Added lifespan manager
-)
+class VmImage(BaseModel):
+    id: str
+    name: str
+    pool: str
+    size: str
+    path: str
 
-# Remove old on_event handlers if they exist (they were in a previous version of the file)
-# @app.on_event("startup")
-# async def startup_event():
-#     ...
-#
-# @app.on_event("shutdown")
-# async def shutdown_event():
-#     ...
-
-# --- Pydantic Models ---
-
-class VmIdPath(BaseModel):
-    vm_id: str = Path(..., description="The ID of the virtual machine (currently ignored, uses mock data for a single VM)")
-
-# Overview Models
 class VCPUInfo(BaseModel):
     count: int
     usage_percent: float
@@ -100,7 +60,7 @@ class OverviewData(BaseModel):
     status: str
     uptime: str
     hostNode: str
-    pool: str # Assuming this refers to a storage pool concept
+    pool: str
     vcpu: VCPUInfo
     vram: VRAMInfo
     bootSource: str
@@ -114,508 +74,47 @@ class LifecycleActionResponse(BaseModel):
     vm_id: str
     action: str
 
-# Snapshots Models
-class SnapshotBase(BaseModel):
-    name: str = Field(..., example="My Snapshot")
-    description: Optional[str] = Field(None, example="A brief description of the snapshot")
-
-class SnapshotCreate(SnapshotBase):
-    pass
-
-class Snapshot(SnapshotBase):
-    id: str = Field(..., example="snap_1678886400")
-    created: datetime = Field(..., example=datetime.now())
-    parentId: Optional[str] = Field(None, example="snap_parent_123")
-    size_mb: int = Field(..., example=1024) # Simplified size
-    xml: Optional[str] = Field(None, example="<domainsnapshot>...</domainsnapshot>")
-
-# 新增：虚拟机实例和镜像的模型，用于从 libvirt 获取真实数据
-class VmInstance(BaseModel):
+class Snapshot(BaseModel):
     id: str
     name: str
-    hostNode: str
-    pool: str
-    state: str
-    vcpu: int
-    vmem: int
-    ip: Optional[str] = None
-    uptime: Optional[str] = None
+    description: Optional[str] = None
+    created: datetime
+    parentId: Optional[str] = None
+    size_mb: int = 0
+    xml: Optional[str] = None
 
-class VmImage(BaseModel):
-    id: str
+class SnapshotCreate(BaseModel):
     name: str
-    pool: str
-    size: str
-    path: str
+    description: Optional[str] = None
 
-
-# --- Mock Data Store ---
-# Using global variables for mock data for simplicity in this example.
-# In a real app, this would be a database or direct libvirt calls.
-
-mock_vm_overview = OverviewData(
-    status="running",
-    uptime="1d 02:30:15",
-    hostNode="mock-hypervisor-01",
-    pool="default_pool",
-    vcpu=VCPUInfo(count=4, usage_percent=random.uniform(10, 70)),
-    vram=VRAMInfo(total_mb=8192, usage_mb=random.randint(2048, 6144), usage_percent=0.0), # usage_percent will be calculated
-    bootSource="Hard Disk",
-    uuid=str(uuid4()),
-    ipAddress="192.168.122.101",
-    disks_rw_mbps=random.uniform(5, 50),
-    network_throughput_mbps=random.uniform(1, 20)
-)
-mock_vm_overview.vram.usage_percent = (mock_vm_overview.vram.usage_mb / mock_vm_overview.vram.total_mb) * 100
-
-mock_snapshots_db: Dict[str, Snapshot] = {}
-
-def init_mock_snapshots():
-    snap1_id = f"snap_{int(datetime.now().timestamp()) - 3600*24*5}"
-    snap1 = Snapshot(
-        id=snap1_id,
-        name="Base Installation",
-        description="Clean OS install with updates.",
-        created=datetime.now() - timedelta(days=5),
-        parentId=None,
-        size_mb=20480, # 20GB
-        xml=f"<domainsnapshot><name>Base Installation</name><memory snapshot='no'/><disks><disk name='vda' snapshot='internal'/></disks></domainsnapshot>"
-    )
-    mock_snapshots_db[snap1.id] = snap1
-
-    snap2_id = f"snap_{int(datetime.now().timestamp()) - 3600*24*2}"
-    snap2 = Snapshot(
-        id=snap2_id,
-        name="Development Tools Installed",
-        description="After installing IDE and other tools.",
-        created=datetime.now() - timedelta(days=2),
-        parentId=snap1.id,
-        size_mb=5120, # 5GB diff
-        xml=f"<domainsnapshot><name>Development Tools Installed</name><memory snapshot='no'/><disks><disk name='vda' snapshot='internal'/></disks></domainsnapshot>"
-    )
-    mock_snapshots_db[snap2.id] = snap2
-
-init_mock_snapshots()
-
-# --- Libvirt 数据获取工具函数 ---
-def fetch_vm_instances() -> List[VmInstance]:
-    """从 libvirt 获取虚拟机实例列表。如果连接不可用则返回空列表。"""
-    instances: List[VmInstance] = []
-    if not LIBVIRT_CONNECTION:
-        return instances
-    try:
-        host_node = LIBVIRT_CONNECTION.getHostname()
-        for dom in LIBVIRT_CONNECTION.listAllDomains():
-            state, _ = dom.state()
-            # 状态码转换为字符串，便于前端显示
-            if state == libvirt.VIR_DOMAIN_RUNNING:
-                state_str = "running"
-            elif state == libvirt.VIR_DOMAIN_PAUSED:
-                state_str = "paused"
-            else:
-                state_str = "shutoff"
-
-            info = dom.info()
-            instance = VmInstance(
-                id=str(dom.ID()),
-                name=dom.name(),
-                hostNode=host_node,
-                pool="default",
-                state=state_str,
-                vcpu=info[3],
-                vmem=int(info[1] / 1024),
-            )
-            instances.append(instance)
-    except libvirt.libvirtError:
-        pass
-    return instances
-
-
-def fetch_vm_images() -> List[VmImage]:
-    """从 libvirt 所有存储池获取镜像卷信息。"""
-    images: List[VmImage] = []
-    if not LIBVIRT_CONNECTION:
-        return images
-    try:
-        for pool in LIBVIRT_CONNECTION.listAllStoragePools():
-            pool.refresh(0)
-            for vol_name in pool.listVolumes():
-                vol = pool.storageVolLookupByName(vol_name)
-                info = vol.info()
-                size_gb = info[1] / (1024 ** 3)
-                images.append(
-                    VmImage(
-                        id=vol_name,
-                        name=vol_name,
-                        pool=pool.name(),
-                        size=f"{size_gb:.1f} GB",
-                        path=vol.path(),
-                    )
-                )
-    except libvirt.libvirtError:
-        pass
-    return images
-
-
-# --- API Endpoints ---
-
-# Overview Endpoints
-@app.get("/api/vm/{vm_id}/overview", response_model=OverviewData, tags=["Overview"])
-async def get_vm_overview(vm_id: str):
-    # In a real app, vm_id would be used to lookup with libvirt
-    # For now, return mock data, updating dynamic fields
-    mock_vm_overview.vcpu.usage_percent = random.uniform(10, 70)
-    mock_vm_overview.vram.usage_mb = random.randint(2048, mock_vm_overview.vram.total_mb)
-    mock_vm_overview.vram.usage_percent = (mock_vm_overview.vram.usage_mb / mock_vm_overview.vram.total_mb) * 100
-    mock_vm_overview.disks_rw_mbps = random.uniform(5, 50)
-    mock_vm_overview.network_throughput_mbps = random.uniform(1, 20)
-    # Simulate uptime increase if status is running
-    if mock_vm_overview.status == "running":
-         # This is a very simplified uptime update. A real one would parse and add.
-        parts = mock_vm_overview.uptime.split(" ")
-        try:
-            days = int(parts[0][:-1])
-            time_parts = parts[1].split(":")
-            hours = int(time_parts[0])
-            minutes = int(time_parts[1])
-            seconds = int(time_parts[2])
-
-            total_seconds = seconds + minutes*60 + hours*3600 + days*86400
-            total_seconds += random.randint(1,5) # Add a few seconds each call
-
-            new_days = total_seconds // 86400
-            rem_seconds = total_seconds % 86400
-            new_hours = rem_seconds // 3600
-            rem_seconds %= 3600
-            new_minutes = rem_seconds // 60
-            new_seconds = rem_seconds % 60
-            mock_vm_overview.uptime = f"{new_days}d {str(new_hours).zfill(2)}:{str(new_minutes).zfill(2)}:{str(new_seconds).zfill(2)}"
-        except:
-            pass # Ignore parsing errors for mock uptime
-
-    return mock_vm_overview
-
-
-# 读取虚拟机实例和镜像列表的接口
-@app.get("/api/vm/instances", response_model=List[VmInstance], tags=["Instances"])
-async def api_vm_instances():
-    """返回所有虚拟机实例信息"""
-    return fetch_vm_instances()
-
-
-@app.get("/api/vm/images", response_model=List[VmImage], tags=["Images"])
-async def api_vm_images():
-    """返回所有存储卷(镜像)信息"""
-    return fetch_vm_images()
-
-# Lifecycle actions
-@app.post("/api/vm/{vm_id}/overview/{action}", response_model=LifecycleActionResponse, tags=["Overview"])
-async def manage_vm_lifecycle(vm_id: str, action: str = Path(..., description="Lifecycle action: start, pause, resume, shutdown, reboot, force-off")):
-    valid_actions = ["start", "pause", "resume", "shutdown", "reboot", "force-off"]
-    if action not in valid_actions:
-        raise HTTPException(status_code=400, detail="Invalid lifecycle action.")
-
-    current_status = mock_vm_overview.status
-    message = f"VM '{vm_id}' action '{action}' initiated."
-
-    if action == "start":
-        if current_status == "shutdown":
-            mock_vm_overview.status = "running"
-            mock_vm_overview.uptime = "0d 00:00:00" # Reset uptime
-        else:
-            message = f"VM '{vm_id}' is already {current_status}. Cannot start."
-            # raise HTTPException(status_code=409, detail=message) # Conflict
-    elif action == "pause":
-        if current_status == "running":
-            mock_vm_overview.status = "paused"
-        else:
-            message = f"VM '{vm_id}' must be running to pause. Current status: {current_status}."
-    elif action == "resume":
-        if current_status == "paused":
-            mock_vm_overview.status = "running"
-        else:
-            message = f"VM '{vm_id}' must be paused to resume. Current status: {current_status}."
-    elif action == "shutdown": # Gentle shutdown
-        if current_status in ["running", "paused"]:
-            mock_vm_overview.status = "shutdown"
-        else:
-            message = f"VM '{vm_id}' is already {current_status} or cannot be shutdown gently."
-    elif action == "reboot": # Gentle reboot
-        if current_status == "running":
-            mock_vm_overview.status = "running" # Simulates reboot: remains running
-            mock_vm_overview.uptime = "0d 00:00:00" # Reset uptime
-        else:
-            message = f"VM '{vm_id}' must be running to reboot. Current status: {current_status}."
-    elif action == "force-off": # Destroy
-        mock_vm_overview.status = "shutdown" # Effectively same as shutdown in mock
-
-    return LifecycleActionResponse(message=message, vm_id=vm_id, action=action)
-
-
-# Snapshots Endpoints
-@app.get("/api/vm/{vm_id}/snapshots", response_model=List[Snapshot], tags=["Snapshots"])
-async def list_vm_snapshots(vm_id: str):
-    # vm_id ignored for now
-    return sorted(list(mock_snapshots_db.values()), key=lambda s: s.created)
-
-@app.post("/api/vm/{vm_id}/snapshots", response_model=Snapshot, status_code=201, tags=["Snapshots"])
-async def create_vm_snapshot(vm_id: str, snapshot_data: SnapshotCreate = Body(...)):
-    # vm_id ignored
-    new_id = f"snap_{int(datetime.now().timestamp())}"
-    # Determine parentId: if a snapshot is selected in UI, it could be passed.
-    # For mock, let's assume the latest snapshot is the parent if not specified.
-    parent_id = None
-    if mock_snapshots_db:
-        latest_snapshot = sorted(mock_snapshots_db.values(), key=lambda s: s.created, reverse=True)
-        if latest_snapshot:
-            parent_id = latest_snapshot[0].id
-            # A more sophisticated mock might take parentId from request if provided
-
-    new_snapshot = Snapshot(
-        id=new_id,
-        name=snapshot_data.name,
-        description=snapshot_data.description,
-        created=datetime.now(),
-        parentId=parent_id, # Mock: could be based on selected snapshot in UI
-        size_mb=random.randint(100, 2000), # Mock size
-        xml=f"<domainsnapshot><name>{snapshot_data.name}</name><description>{snapshot_data.description or ''}</description></domainsnapshot>"
-    )
-    mock_snapshots_db[new_id] = new_snapshot
-    return new_snapshot
-
-@app.post("/api/vm/{vm_id}/snapshots/{snapshot_id}/revert", tags=["Snapshots"])
-async def revert_to_vm_snapshot(vm_id: str, snapshot_id: str = Path(..., description="ID of the snapshot to revert to")):
-    # vm_id ignored
-    if snapshot_id not in mock_snapshots_db:
-        raise HTTPException(status_code=404, detail=f"Snapshot with ID '{snapshot_id}' not found.")
-    # Mock action: just a message. In reality, VM state would change.
-    mock_vm_overview.status = "running" # Assume VM is running after revert
-    mock_vm_overview.uptime = "0d 00:00:00" # Uptime might reset
-    return {"message": f"VM '{vm_id}' reverted to snapshot '{mock_snapshots_db[snapshot_id].name}' (mock action)."}
-
-@app.delete("/api/vm/{vm_id}/snapshots/{snapshot_id}", status_code=204, tags=["Snapshots"])
-async def delete_vm_snapshot(vm_id: str, snapshot_id: str = Path(..., description="ID of the snapshot to delete")):
-    # vm_id ignored
-    if snapshot_id not in mock_snapshots_db:
-        raise HTTPException(status_code=404, detail=f"Snapshot with ID '{snapshot_id}' not found.")
-
-    # Mock: check for children. Real libvirt might handle this differently or require flags.
-    children = [sid for sid, snap in mock_snapshots_db.items() if snap.parentId == snapshot_id]
-    if children:
-        # Simplistic mock: delete children too. Real app might prevent or offer re-parenting.
-        for child_id in children:
-            del mock_snapshots_db[child_id]
-        # raise HTTPException(status_code=409, detail=f"Snapshot '{mock_snapshots_db[snapshot_id].name}' has children. Delete them first or use a recursive delete option (mock limitation).")
-
-    del mock_snapshots_db[snapshot_id]
-    return None # No content for 204
-
-# --- Storage Models & Endpoints ---
 class Disk(BaseModel):
     id: str
     target: str
     source: str
-    format: str # qcow2, raw
-    bus: str # virtio, sata, scsi, ide
+    format: str
+    bus: str
     capacity_gb: int
     allocated_gb: int
-    iops_rw: Optional[str] = None # e.g., "120/60"
-
-class CreateDisk(BaseModel):
-    pool_name: str = Field("default", example="data_pool")
-    capacity_gb: int = Field(..., example=20, gt=0)
-    format: str = Field("qcow2", example="qcow2", pattern="^(qcow2|raw)$")
-    bus: str = Field("virtio", example="virtio", pattern="^(virtio|sata|scsi|ide)$")
-
-class ResizeDisk(BaseModel):
-    new_capacity_gb: int = Field(..., example=100, gt=0)
+    iops_rw: Optional[str] = None
 
 class CdRomDevice(BaseModel):
     id: str
     target: str
-    source_iso: Optional[str] = None
+    source_iso: Optional[str]
     mounted: bool
 
-class MountIso(BaseModel):
-    iso_path: str = Field(..., example="/isos/ubuntu-live.iso")
-
-
-mock_disks_db: Dict[str, Disk] = {
-    "disk_vda": Disk(id="disk_vda", target="vda", source="/var/lib/libvirt/images/vm1-disk1.qcow2", format="qcow2", bus="virtio", capacity_gb=50, allocated_gb=25, iops_rw="120/60"),
-    "disk_vdb": Disk(id="disk_vdb", target="vdb", source="pool1/vm1-disk2.raw", format="raw", bus="sata", capacity_gb=100, allocated_gb=80, iops_rw="90/40"),
-}
-
-mock_cdroms_db: Dict[str, CdRomDevice] = {
-    "cdrom_sda": CdRomDevice(id="cdrom_sda", target="sda", mounted=True, source_iso="/isos/ubuntu-22.04.iso"),
-    "cdrom_sdb": CdRomDevice(id="cdrom_sdb", target="sdb", mounted=False),
-}
-
-
-@app.get("/api/vm/{vm_id}/storage/disks", response_model=List[Disk], tags=["Storage"])
-async def list_vm_disks(vm_id: str):
-    return list(mock_disks_db.values())
-
-@app.post("/api/vm/{vm_id}/storage/disks", response_model=Disk, status_code=201, tags=["Storage"])
-async def add_vm_disk(vm_id: str, disk_data: CreateDisk):
-    new_target_char_code = ord('a') + len(mock_disks_db)
-    if new_target_char_code > ord('z'): # Simple check for too many disks
-        new_target_char_code = random.randint(ord('a'), ord('z')) # fallback for mock
-
-    new_target = f"vd{chr(new_target_char_code)}"
-    new_disk_id = f"disk_{new_target}"
-
-    if new_disk_id in mock_disks_db : # handle unlikely collision in mock
-        new_target = f"vd{chr(new_target_char_code)}{random.randint(1,9)}"
-        new_disk_id = f"disk_{new_target}"
-
-
-    new_disk = Disk(
-        id=new_disk_id,
-        target=new_target,
-        source=f"{disk_data.pool_name}/new_disk_{new_target}.{disk_data.format}",
-        format=disk_data.format,
-        bus=disk_data.bus,
-        capacity_gb=disk_data.capacity_gb,
-        allocated_gb=0, # New disks start with 0 allocated for mock
-        iops_rw="0/0"
-    )
-    mock_disks_db[new_disk_id] = new_disk
-    return new_disk
-
-@app.delete("/api/vm/{vm_id}/storage/disks/{disk_id}", status_code=204, tags=["Storage"])
-async def delete_vm_disk(vm_id: str, disk_id: str):
-    if disk_id not in mock_disks_db:
-        raise HTTPException(status_code=404, detail=f"Disk with ID '{disk_id}' not found.")
-    del mock_disks_db[disk_id]
-    return None
-
-@app.post("/api/vm/{vm_id}/storage/disks/{disk_id}/resize", response_model=Disk, tags=["Storage"])
-async def resize_vm_disk(vm_id: str, disk_id: str, resize_data: ResizeDisk):
-    if disk_id not in mock_disks_db:
-        raise HTTPException(status_code=404, detail=f"Disk with ID '{disk_id}' not found.")
-
-    disk_to_resize = mock_disks_db[disk_id]
-    if resize_data.new_capacity_gb <= disk_to_resize.capacity_gb:
-        raise HTTPException(status_code=400, detail="New capacity must be greater than current capacity.")
-
-    disk_to_resize.capacity_gb = resize_data.new_capacity_gb
-    # In a real scenario, allocated_gb might also change or need checks
-    return disk_to_resize
-
-
-@app.get("/api/vm/{vm_id}/storage/cdroms", response_model=List[CdRomDevice], tags=["Storage"])
-async def list_vm_cdroms(vm_id: str):
-    return list(mock_cdroms_db.values())
-
-@app.post("/api/vm/{vm_id}/storage/cdroms/{cdrom_id}/mount", response_model=CdRomDevice, tags=["Storage"])
-async def mount_iso_to_cdrom(vm_id: str, cdrom_id: str, mount_data: MountIso):
-    if cdrom_id not in mock_cdroms_db:
-        raise HTTPException(status_code=404, detail=f"CD-ROM device with ID '{cdrom_id}' not found.")
-
-    cdrom_device = mock_cdroms_db[cdrom_id]
-    cdrom_device.source_iso = mount_data.iso_path
-    cdrom_device.mounted = True
-    return cdrom_device
-
-@app.post("/api/vm/{vm_id}/storage/cdroms/{cdrom_id}/eject", response_model=CdRomDevice, tags=["Storage"])
-async def eject_iso_from_cdrom(vm_id: str, cdrom_id: str):
-    if cdrom_id not in mock_cdroms_db:
-        raise HTTPException(status_code=404, detail=f"CD-ROM device with ID '{cdrom_id}' not found.")
-
-    cdrom_device = mock_cdroms_db[cdrom_id]
-    cdrom_device.source_iso = None
-    cdrom_device.mounted = False
-    return cdrom_device
-
-
-# --- Network Models & Endpoints ---
 class VirtualNic(BaseModel):
     id: str
     mac: str
     bridge: str
-    model: str # virtio, e1000, rtl8139
+    model: str
     pciAddress: Optional[str] = None
     rx_rate_kbps: int
     tx_rate_kbps: int
-    status: str # active, inactive, unplugged
+    status: str
     bandwidth_limit_mbps: Optional[int] = None
     vlan_tag: Optional[int] = None
 
-class CreateNic(BaseModel):
-    bridge: str = Field("virbr0", example="virbr0")
-    model: str = Field("virtio", example="virtio", pattern="^(virtio|e1000|rtl8139)$")
-    vlan_tag: Optional[int] = Field(None, example=10, ge=1, le=4094)
-    bandwidth_limit_mbps: Optional[int] = Field(None, example=100, gt=0)
-
-class UpdateNic(CreateNic): # Can reuse CreateNic for updates, or make specific fields optional
-    pass
-
-
-mock_vnics_db: Dict[str, VirtualNic] = {
-    "nic_525400AABBCC": VirtualNic(id="nic_525400AABBCC", mac="52:54:00:AA:BB:CC", bridge="virbr0", model="virtio", pciAddress="0000:01:00.0", rx_rate_kbps=random.randint(0,2000), tx_rate_kbps=random.randint(0,1000), status="active", bandwidth_limit_mbps=100, vlan_tag=10),
-    "nic_525400DDEEFF": VirtualNic(id="nic_525400DDEEFF", mac="52:54:00:DD:EE:FF", bridge="br-lan", model="e1000", pciAddress="0000:02:00.0", rx_rate_kbps=0, tx_rate_kbps=0, status="inactive"),
-}
-
-def generate_mac():
-    return "52:54:00:" + ":".join(f"{random.randint(0, 255):02X}" for _ in range(3))
-
-
-@app.get("/api/vm/{vm_id}/network/vnics", response_model=List[VirtualNic], tags=["Network"])
-async def list_vm_vnics(vm_id: str):
-    # Simulate dynamic rates
-    for nic in mock_vnics_db.values():
-        if nic.status == "active":
-            nic.rx_rate_kbps = random.randint(0, 2000)
-            nic.tx_rate_kbps = random.randint(0, 1000)
-        else:
-            nic.rx_rate_kbps = 0
-            nic.tx_rate_kbps = 0
-    return list(mock_vnics_db.values())
-
-@app.post("/api/vm/{vm_id}/network/vnics", response_model=VirtualNic, status_code=201, tags=["Network"])
-async def attach_vm_vnic(vm_id: str, nic_data: CreateNic):
-    new_mac = generate_mac()
-    new_id = f"nic_{new_mac.replace(':', '')}"
-    # Simplified PCI address for mock
-    pci_slot = len(mock_vnics_db) + 1
-
-    new_vnic = VirtualNic(
-        id=new_id,
-        mac=new_mac,
-        bridge=nic_data.bridge,
-        model=nic_data.model,
-        pciAddress=f"0000:0{pci_slot}:00.0",
-        rx_rate_kbps=0,
-        tx_rate_kbps=0,
-        status="active", # Assume new NICs are active
-        bandwidth_limit_mbps=nic_data.bandwidth_limit_mbps,
-        vlan_tag=nic_data.vlan_tag
-    )
-    mock_vnics_db[new_id] = new_vnic
-    return new_vnic
-
-@app.put("/api/vm/{vm_id}/network/vnics/{vnic_id}", response_model=VirtualNic, tags=["Network"])
-async def update_vm_vnic(vm_id: str, vnic_id: str, nic_data: UpdateNic):
-    if vnic_id not in mock_vnics_db:
-        raise HTTPException(status_code=404, detail=f"vNIC with ID '{vnic_id}' not found.")
-
-    vnic_to_update = mock_vnics_db[vnic_id]
-    vnic_to_update.bridge = nic_data.bridge
-    vnic_to_update.model = nic_data.model
-    vnic_to_update.vlan_tag = nic_data.vlan_tag
-    vnic_to_update.bandwidth_limit_mbps = nic_data.bandwidth_limit_mbps
-    # Note: MAC, PCI, status changes are more complex and not handled simply here.
-    return vnic_to_update
-
-@app.delete("/api/vm/{vm_id}/network/vnics/{vnic_id}", status_code=204, tags=["Network"])
-async def detach_vm_vnic(vm_id: str, vnic_id: str):
-    if vnic_id not in mock_vnics_db:
-        raise HTTPException(status_code=404, detail=f"vNIC with ID '{vnic_id}' not found.")
-    del mock_vnics_db[vnic_id]
-    return None
-
-
-# --- Performance Models & Endpoints ---
 class MetricDataPoint(BaseModel):
     timestamp: datetime
     value: float
@@ -623,220 +122,279 @@ class MetricDataPoint(BaseModel):
 class HistoricalMetrics(BaseModel):
     cpu_percent: List[MetricDataPoint]
     memory_mb: List[MetricDataPoint]
-    # Disk and Network can be more complex (read/write, rx/tx)
-    # For simplicity, using single values for now.
     disk_rw_mbps_total: List[MetricDataPoint]
     network_throughput_mbps_total: List[MetricDataPoint]
-
-# Mock historical data generator
-def generate_historical_data(range_str: str, points: int = 60) -> HistoricalMetrics:
-    now = datetime.now()
-    metrics = {
-        "cpu_percent": [], "memory_mb": [],
-        "disk_rw_mbps_total": [], "network_throughput_mbps_total": []
-    }
-
-    time_delta_map = {"1h": timedelta(hours=1), "24h": timedelta(days=1), "7d": timedelta(days=7)}
-    total_duration = time_delta_map.get(range_str, timedelta(hours=1))
-    time_step = total_duration / points
-
-    for i in range(points):
-        ts = now - total_duration + (i * time_step)
-        metrics["cpu_percent"].append(MetricDataPoint(timestamp=ts, value=random.uniform(5, 80)))
-        metrics["memory_mb"].append(MetricDataPoint(timestamp=ts, value=random.uniform(1024, mock_vm_overview.vram.total_mb * 0.9)))
-        metrics["disk_rw_mbps_total"].append(MetricDataPoint(timestamp=ts, value=random.uniform(1, 30)))
-        metrics["network_throughput_mbps_total"].append(MetricDataPoint(timestamp=ts, value=random.uniform(0.5, 15)))
-
-    return HistoricalMetrics(**metrics)
-
-
-@app.get("/api/vm/{vm_id}/performance/current", response_model=OverviewData, tags=["Performance"]) # Reusing OverviewData for simplicity
-async def get_current_performance(vm_id: str):
-    # This is largely redundant with /overview, but specific to "current performance" numbers
-    # In a real system, this might poll more frequently or use different aggregation
-    return await get_vm_overview(vm_id) # Just call the existing overview logic
-
-@app.get("/api/vm/{vm_id}/performance/historical", response_model=HistoricalMetrics, tags=["Performance"])
-async def get_historical_performance(vm_id: str, range: str = "1h"):
-    if range not in ["1h", "24h", "7d"]:
-        raise HTTPException(status_code=400, detail="Invalid range. Must be one of: 1h, 24h, 7d.")
-    return generate_historical_data(range)
-
-
-# --- Events Models & Endpoints ---
-class EventLogLevel(str, Enum): # Changed to inherit from str and Enum
-    INFO = "info"
-    WARNING = "warning"
-    ERROR = "error"
-    DEBUG = "debug"
 
 class EventLog(BaseModel):
     id: str
     timestamp: datetime
-    level: EventLogLevel
+    level: str
     message: str
     details: Optional[Dict[str, Any]] = None
 
+# ---------------- Helper Functions ----------------
+def _require_conn():
+    if not LIBVIRT_CONNECTION:
+        raise HTTPException(status_code=503, detail="libvirt 未连接")
+    return LIBVIRT_CONNECTION
 
-mock_events_db: List[EventLog] = []
+# 获取所有虚拟机实例
+def fetch_vm_instances() -> List[VmInstance]:
+    conn = _require_conn()
+    host = conn.getHostname()
+    instances: List[VmInstance] = []
+    for dom in conn.listAllDomains():
+        info = dom.info()
+        state_code = info[0]
+        if state_code == libvirt.VIR_DOMAIN_RUNNING:
+            state = "running"
+        elif state_code == libvirt.VIR_DOMAIN_PAUSED:
+            state = "paused"
+        else:
+            state = "shutoff"
+        instances.append(
+            VmInstance(
+                id=str(dom.ID()),
+                name=dom.name(),
+                hostNode=host,
+                pool="default",
+                state=state,
+                vcpu=info[3],
+                vmem=int(info[2] / 1024),
+            )
+        )
+    return instances
 
-def init_mock_events():
-    base_time = datetime.now()
-    mock_events_db.extend([
-        EventLog(id=str(uuid4()), timestamp=base_time - timedelta(hours=2), level=EventLogLevel.INFO, message="VM Guest OS booted successfully.", details={"source": "kernel"}),
-        EventLog(id=str(uuid4()), timestamp=base_time - timedelta(minutes=50), level=EventLogLevel.DEBUG, message="Network interface eth0 link up.", details={"speed": "1000Mbps"}),
-        EventLog(id=str(uuid4()), timestamp=base_time - timedelta(minutes=30), level=EventLogLevel.WARNING, message="High CPU utilization detected.", details={"usage": "92%", "threshold": "90%"}),
-        EventLog(id=str(uuid4()), timestamp=base_time - timedelta(minutes=10), level=EventLogLevel.INFO, message=f"Snapshot '{list(mock_snapshots_db.values())[0].name if mock_snapshots_db else 'backup_daily'}' created.", details={"user": "admin"}),
-        EventLog(id=str(uuid4()), timestamp=base_time - timedelta(minutes=5), level=EventLogLevel.ERROR, message="Failed to attach storage volume 'data_vol_03'.", details={"reason": "Volume not found"}),
-        EventLog(id=str(uuid4()), timestamp=base_time - timedelta(minutes=1), level=EventLogLevel.INFO, message="User 'jdoe' connected via VNC.", details={"ip": "192.168.1.105"}),
-    ])
-    # Periodically add a new mock event if live tail is considered
-    # For now, this is just initial data.
+# 获取所有存储卷信息
+def fetch_vm_images() -> List[VmImage]:
+    conn = _require_conn()
+    images: List[VmImage] = []
+    for pool in conn.listAllStoragePools():
+        pool.refresh(0)
+        for vol_name in pool.listVolumes():
+            vol = pool.storageVolLookupByName(vol_name)
+            size_gb = vol.info()[1] / (1024 ** 3)
+            images.append(
+                VmImage(
+                    id=vol_name,
+                    name=vol_name,
+                    pool=pool.name(),
+                    size=f"{size_gb:.1f} GB",
+                    path=vol.path(),
+                )
+            )
+    return images
 
-init_mock_events()
+# ---------------- API Endpoints ----------------
+@app.get("/api/vm/instances", response_model=List[VmInstance])
+def api_vm_instances():
+    return fetch_vm_instances()
 
-@app.get("/api/vm/{vm_id}/events", response_model=List[EventLog], tags=["Events"])
-async def list_vm_events(
-    vm_id: str,
-    level: Optional[EventLogLevel] = None,
-    keyword: Optional[str] = None,
-    time_window: Optional[str] = None, # e.g., "1h", "6h", "24h", "all"
-    limit: int = 100
-):
-    filtered_events = mock_events_db
+@app.get("/api/vm/images", response_model=List[VmImage])
+def api_vm_images():
+    return fetch_vm_images()
 
-    if level:
-        filtered_events = [e for e in filtered_events if e.level == level]
-
-    if keyword:
-        kw = keyword.lower()
-        filtered_events = [
-            e for e in filtered_events
-            if kw in e.message.lower() or (e.details and kw in str(e.details).lower())
-        ]
-
-    if time_window and time_window != "all":
-        now = datetime.now()
-        delta = None
-        if time_window == "1h": delta = timedelta(hours=1)
-        elif time_window == "6h": delta = timedelta(hours=6)
-        elif time_window == "24h": delta = timedelta(days=1)
-
-        if delta:
-            start_time = now - delta
-            filtered_events = [e for e in filtered_events if e.timestamp >= start_time]
-
-    return sorted(filtered_events, key=lambda e: e.timestamp, reverse=True)[:limit]
-
-
-# (Optional) Add a requirements.txt for the backend
-# For now, dependencies are fastapi, uvicorn, python-dotenv (optional), libvirt-python (when used)
-
-# To run this application:
-# 1. Save as backend/main.py
-# 2. Install dependencies: pip install fastapi uvicorn
-# 3. Run from the project root: uvicorn backend.main:app --reload --port 8000
-#    (or from backend folder: uvicorn main:app --reload --port 8000)
-
-# --- Libvirt Connection Framework ---
-LIBVIRT_CONNECTION = None
-
-def get_libvirt_connection():
-    """Attempts to establish a libvirt connection based on the OS."""
-    global libvirt # Make sure to use the global import if it's conditional
+@app.get("/api/vm/{vm_id}/overview", response_model=OverviewData)
+def get_vm_overview(vm_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    info = dom.info()
+    state_code = info[0]
+    if state_code == libvirt.VIR_DOMAIN_RUNNING:
+        status = "running"
+    elif state_code == libvirt.VIR_DOMAIN_PAUSED:
+        status = "paused"
+    else:
+        status = "shutoff"
+    total_mb = int(info[1] / 1024)
+    used_mb = int(info[2] / 1024)
+    vram = VRAMInfo(total_mb=total_mb, usage_mb=used_mb, usage_percent=used_mb / total_mb * 100)
+    vcpu = VCPUInfo(count=info[3], usage_percent=0.0)
+    ip = None
     try:
-        import libvirt # Try importing here, so it's only required if this function is called
-    except ImportError:
-        print("Libvirt-python library not found. Please install it to connect to libvirt.")
+        ifaces = dom.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT, 0)
+        for val in ifaces.values():
+            if val['addrs']:
+                ip = val['addrs'][0]['addr']
+                break
+    except libvirt.libvirtError:
+        pass
+    return OverviewData(
+        status=status,
+        uptime="N/A",
+        hostNode=conn.getHostname(),
+        pool="default",
+        vcpu=vcpu,
+        vram=vram,
+        bootSource="disk",
+        uuid=dom.UUIDString(),
+        ipAddress=ip or "",
+        disks_rw_mbps=0.0,
+        network_throughput_mbps=0.0,
+    )
+
+@app.post("/api/vm/{vm_id}/overview/{action}", response_model=LifecycleActionResponse)
+def manage_vm_lifecycle(vm_id: str, action: str = Path(...)):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    try:
+        if action == "start":
+            dom.create()
+        elif action == "pause":
+            dom.suspend()
+        elif action == "resume":
+            dom.resume()
+        elif action == "shutdown":
+            dom.shutdown()
+        elif action == "reboot":
+            dom.reboot()
+        elif action == "force-off":
+            dom.destroy()
+        else:
+            raise HTTPException(status_code=400, detail="未知操作")
+    except libvirt.libvirtError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return LifecycleActionResponse(message="ok", vm_id=vm_id, action=action)
+
+@app.get("/api/vm/{vm_id}/snapshots", response_model=List[Snapshot])
+def list_vm_snapshots(vm_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    snaps = []
+    for name in dom.snapshotListNames(0):
+        snap = dom.snapshotLookupByName(name, 0)
+        info = snap.getInfo()
+        snaps.append(
+            Snapshot(
+                id=name,
+                name=name,
+                created=datetime.fromtimestamp(info[1]),
+                xml=snap.getXMLDesc(),
+            )
+        )
+    return snaps
+
+@app.post("/api/vm/{vm_id}/snapshots", response_model=Snapshot)
+def create_vm_snapshot(vm_id: str, snapshot_data: SnapshotCreate):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    snap_xml = f"<domainsnapshot><name>{snapshot_data.name}</name><description>{snapshot_data.description or ''}</description></domainsnapshot>"
+    try:
+        snap = dom.snapshotCreateXML(snap_xml, 0)
+        info = snap.getInfo()
+        return Snapshot(id=snap.getName(), name=snap.getName(), description=snapshot_data.description, created=datetime.fromtimestamp(info[1]), xml=snap.getXMLDesc())
+    except libvirt.libvirtError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/api/vm/{vm_id}/snapshots/{snapshot_id}/revert")
+def revert_to_vm_snapshot(vm_id: str, snapshot_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    snap = dom.snapshotLookupByName(snapshot_id, 0)
+    try:
+        snap.revertToSnapshot(0)
+        return {"message": "reverted"}
+    except libvirt.libvirtError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.delete("/api/vm/{vm_id}/snapshots/{snapshot_id}")
+def delete_vm_snapshot(vm_id: str, snapshot_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    snap = dom.snapshotLookupByName(snapshot_id, 0)
+    try:
+        snap.delete(0)
         return None
+    except libvirt.libvirtError as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
-    system = platform.system()
-    conn = None
-    uri = None
+@app.get("/api/vm/{vm_id}/storage/disks", response_model=List[Disk])
+def list_vm_disks(vm_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    xml = dom.XMLDesc(0)
+    import xml.etree.ElementTree as ET
+    tree = ET.fromstring(xml)
+    disks: List[Disk] = []
+    for disk in tree.findall(".//devices/disk[@device='disk']"):
+        target = disk.find("target").get("dev")
+        source = disk.find("source")
+        path = source.get("file") if source is not None else None
+        if not path:
+            continue
+        vol = conn.storageVolLookupByPath(path)
+        info = vol.info()
+        disks.append(
+            Disk(
+                id=target,
+                target=target,
+                source=path,
+                format=disk.find("driver").get("type"),
+                bus=disk.find("target").get("bus"),
+                capacity_gb=int(info[1] / (1024 ** 3)),
+                allocated_gb=int(info[2] / (1024 ** 3)),
+            )
+        )
+    return disks
 
-    if system == "Linux":
-        uri = "qemu:///system"
-        print(f"Detected Linux system. Attempting local libvirt connection: {uri}")
-        try:
-            conn = libvirt.open(uri)
-        except libvirt.libvirtError as e:
-            print(f"Failed to connect to local libvirt (Linux): {e}")
-            if os.getenv("WSL_DISTRO_NAME"):
-                print("Running inside WSL, but local connection failed. Ensure libvirtd service is active and configured.")
-            conn = None
-    elif system == "Windows":
-        wsl_ip = os.getenv("WSL_LIBVIRT_IP")
-        if not wsl_ip:
-            print("Windows system: WSL_LIBVIRT_IP environment variable not set. Cannot connect to WSL libvirt.")
-            # Optionally, attempt to dynamically get WSL IP here if desired, as discussed previously.
-            # For now, we rely on the environment variable.
-            return None
+@app.get("/api/vm/{vm_id}/storage/cdroms", response_model=List[CdRomDevice])
+def list_vm_cdroms(vm_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    xml = dom.XMLDesc(0)
+    import xml.etree.ElementTree as ET
+    tree = ET.fromstring(xml)
+    cds: List[CdRomDevice] = []
+    for disk in tree.findall(".//devices/disk[@device='cdrom']"):
+        target = disk.find("target").get("dev")
+        source_elem = disk.find("source")
+        iso = source_elem.get("file") if source_elem is not None else None
+        mounted = iso is not None
+        cds.append(CdRomDevice(id=target, target=target, source_iso=iso, mounted=mounted))
+    return cds
 
-        uri = f"qemu+tcp://{wsl_ip}:16509/system" # Default libvirt TCP port
-        print(f"Detected Windows system. Attempting to connect to WSL libvirt via TCP: {uri}")
-        try:
-            conn = libvirt.open(uri)
-        except libvirt.libvirtError as e:
-            print(f"Failed to connect to WSL libvirt via TCP (Windows): {e}")
-            conn = None
-    else:
-        print(f"Unsupported OS for libvirt connection: {system}")
-        return None
+@app.get("/api/vm/{vm_id}/network/vnics", response_model=List[VirtualNic])
+def list_vm_vnics(vm_id: str):
+    conn = _require_conn()
+    dom = conn.lookupByID(int(vm_id))
+    xml = dom.XMLDesc(0)
+    import xml.etree.ElementTree as ET
+    tree = ET.fromstring(xml)
+    nics: List[VirtualNic] = []
+    for iface in tree.findall(".//devices/interface[@type='bridge']"):
+        mac = iface.find("mac").get("address")
+        bridge = iface.find("source").get("bridge")
+        model = iface.find("model").get("type")
+        target_elem = iface.find("target")
+        target = target_elem.get("dev") if target_elem is not None else None
+        stats = dom.interfaceStats(target) if target else (0,0,0,0,0,0,0,0)
+        rx = stats[0]
+        tx = stats[4]
+        nics.append(
+            VirtualNic(
+                id=mac.replace(":", ""),
+                mac=mac,
+                bridge=bridge,
+                model=model,
+                pciAddress=None,
+                rx_rate_kbps=int(rx/1024),
+                tx_rate_kbps=int(tx/1024),
+                status="active",
+            )
+        )
+    return nics
 
-    if conn is None:
-        print("Failed to establish libvirt connection. API will use mock data or operate in a limited mode.")
-    else:
-        print("Successfully connected to libvirt service.")
-    return conn
+@app.get("/api/vm/{vm_id}/performance/historical", response_model=HistoricalMetrics)
+def get_historical_performance(vm_id: str, range: str = "1h"):
+    # 由于缺乏持久化，此处仅返回空数据
+    return HistoricalMetrics(cpu_percent=[], memory_mb=[], disk_rw_mbps_total=[], network_throughput_mbps_total=[])
 
-# @app.on_event("startup") # REMOVED - Replaced by lifespan manager
-# async def startup_event():
-#     global LIBVIRT_CONNECTION
-#     print("FastAPI application starting up. Attempting to initialize libvirt connection...")
-#     LIBVIRT_CONNECTION = get_libvirt_connection()
-#     if LIBVIRT_CONNECTION:
-#         try:
-#             hostname = LIBVIRT_CONNECTION.getHostname()
-#             print(f"Libvirt connection successful. Hostname: {hostname}")
-#         except Exception as e: # Catch potential errors if connection drops immediately
-#             print(f"Libvirt connection established but failed to get hostname: {e}")
-#             LIBVIRT_CONNECTION = None # Reset if post-connection check fails
-#             print("Reverted to no Libvirt connection due to post-connection check failure.")
-#     else:
-#         print("Libvirt connection failed during startup. Backend will use mock data.")
-#         print("Ensure libvirt service is running and configured correctly.")
-#         print("- On Linux/WSL: Check 'sudo systemctl status libvirtd' or 'sudo service libvirtd status'.")
-#         print("- On Windows (for WSL connection): Set WSL_LIBVIRT_IP and ensure WSL's libvirtd listens on TCP.")
-
-# @app.on_event("shutdown") # REMOVED - Replaced by lifespan manager
-# async def shutdown_event():
-#     global LIBVIRT_CONNECTION
-#     if LIBVIRT_CONNECTION:
-#         print("FastAPI application shutting down. Closing libvirt connection...")
-#         try:
-#             LIBVIRT_CONNECTION.close()
-#             print("Libvirt connection closed.")
-#         except Exception as e: # Use generic Exception for libvirt.libvirtError if import is conditional
-#             print(f"Error closing libvirt connection: {e}")
-#         LIBVIRT_CONNECTION = None
-
-# --- End Libvirt Connection Framework ---
-
-# Note: The lifespan manager is defined earlier and passed to FastAPI app instance:
-# @asynccontextmanager
-# async def lifespan(app_instance: FastAPI): ...
-# app = FastAPI(..., lifespan=lifespan)
+@app.get("/api/vm/{vm_id}/events", response_model=List[EventLog])
+def list_vm_events(vm_id: str):
+    # 未实现事件持久化，暂返回空列表
+    return []
 
 if __name__ == "__main__":
     import uvicorn
-    # Ensure PYTHON_API_PORT from server.js (default 8000) is used if main.py is run directly.
-    # However, when spawned by server.js, server.js controls the port uvicorn *should* listen on.
-    # For direct execution (python src/main.py), we'll use a common default.
-    # The uvicorn.run() call here is primarily for when this script is executed directly.
-    # When server.js runs this script, these specific host/port values are less critical
-    # as server.js *expects* it to be on PYTHON_API_PORT.
-    # For consistency, we'll use 0.0.0.0 and a default port.
-
-    configured_port = int(os.getenv("PYTHON_API_PORT", "3010"))
-    print(f"Attempting to start Uvicorn programmatically on host 0.0.0.0, port {configured_port}")
-    uvicorn.run(app, host="0.0.0.0", port=configured_port, log_level="info")
+    port = int(os.getenv("PYTHON_API_PORT", "3010"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node server.js",
+    "dev": "node --trace-deprecation server.js",
     "build": "TSC_COMPILE_ON_ERROR=true next build",
     "start": "NODE_ENV=production node server.js"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -14,6 +14,9 @@ const handle = app.getRequestHandler();
 const PYTHON_API_PORT = process.env.PYTHON_API_PORT || 3010;
 const PYTHON_API_HOST = process.env.PYTHON_API_HOST || '127.0.0.1'; // Use 127.0.0.1 for proxy target
 const FASTAPI_TARGET_URL = `http://${PYTHON_API_HOST}:${PYTHON_API_PORT}`;
+const PHP_API_PORT = process.env.PHP_API_PORT || 8000;
+const PHP_API_HOST = process.env.PHP_API_HOST || '127.0.0.1';
+const PHP_TARGET_URL = `http://${PHP_API_HOST}:${PHP_API_PORT}`;
 
 app.prepare().then(() => {
   let pythonExecutable;
@@ -99,8 +102,30 @@ app.prepare().then(() => {
     onProxyReq: (proxyReq, req, res) => {
         console.log(`[Proxy] Request to FastAPI: ${req.method} ${req.url} -> ${FASTAPI_TARGET_URL}${proxyReq.path}`);
     },
-     onProxyRes: (proxyRes, req, res) => {
-        console.log(`[Proxy] Response from FastAPI: ${proxyRes.statusCode} for ${req.url}`);
+    onProxyRes: (proxyRes, req, res) => {
+      console.log(`[Proxy] Response from FastAPI: ${proxyRes.statusCode} for ${req.url}`);
+    }
+  });
+
+  // Proxy middleware for PHP backend requests
+  console.log('[Debug HPM] Intended PHP Proxy Target URL:', PHP_TARGET_URL);
+  const phpProxy = createProxyMiddleware({
+    target: PHP_TARGET_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/php': '/api' },
+    logLevel: dev ? 'debug' : 'info',
+    onError: (err, req, res) => {
+      console.error('PHP Proxy error:', err);
+      if (res && !res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'PHP Proxy Error', error: err.message }));
+      }
+    },
+    onProxyReq: (proxyReq, req, res) => {
+      console.log(`[Proxy] Request to PHP: ${req.method} ${req.url} -> ${PHP_TARGET_URL}${proxyReq.path}`);
+    },
+    onProxyRes: (proxyRes, req, res) => {
+      console.log(`[Proxy] Response from PHP: ${proxyRes.statusCode} for ${req.url}`);
     }
   });
 
@@ -125,6 +150,16 @@ app.prepare().then(() => {
         res.end(JSON.stringify({ message: 'Python backend service (for /api/vm) is unavailable on this platform.' }));
         return;
       }
+    } else if (req.url && req.url.startsWith('/api/php')) {
+      return phpProxy(req, res, (err) => {
+        if (err) {
+          console.error('Error in PHP proxy middleware:', err);
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'text/plain' });
+            res.end('Proxy middleware error.');
+          }
+        }
+      });
     }
     // Default to Next.js handler for other requests
     return handle(req, res);
@@ -163,6 +198,7 @@ app.prepare().then(() => {
     .listen(port, () => {
       console.log(`> Node.js server ready on http://localhost:${port}`);
       console.log(`> FastAPI (Python) API available via proxy at http://localhost:${port}/api/vm`);
+      console.log(`> PHP API available via proxy at http://localhost:${port}/api/php`);
       console.log(`> Terminal WebSocket available at ws://localhost:${port}/api/terminal`);
     });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -112,7 +112,7 @@ app.prepare().then(() => {
   const phpProxy = createProxyMiddleware({
     target: PHP_TARGET_URL,
     changeOrigin: true,
-    pathRewrite: { '^/api/php': '/api' },
+    pathRewrite: { '^/api/php': '/' },
     logLevel: dev ? 'debug' : 'info',
     onError: (err, req, res) => {
       console.error('PHP Proxy error:', err);


### PR DESCRIPTION
## Summary
- fetch real VM lists and images from libvirt in FastAPI
- expose `/api/vm/instances` and `/api/vm/images`
- update VM instances and images pages to call new API
- pass real VM IDs to VM detail panels
- adjust all panels to accept `vmId` prop

## Testing
- `npm run build` *(fails: next not found)*
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686556b14ef88320b7825f7e9e0ff870