### PR TITLE
Improve VM image metadata retrieval

### DIFF
--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -37,13 +37,13 @@ import dayjs from "dayjs"
 interface VmImage {
     id: string
     name: string
-    version: string
-    osType: "Windows" | "Linux" | "Other"
-    architecture: "x86_64" | "arm64"
+    version?: string
+    osType?: "Windows" | "Linux" | "Other"
+    architecture?: "x86_64" | "arm64"
     size: string
-    description: string
-    uploadDate: string
-    status: "available" | "uploading" | "error"
+    description?: string
+    uploadDate?: string
+    status?: "available" | "uploading" | "error"
     filePath?: string
 }
 
@@ -73,10 +73,10 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
             setEditingImage(image)
             setFormData({
                 name: image.name,
-                version: image.version,
-                osType: image.osType,
-                architecture: image.architecture,
-                description: image.description,
+                version: image.version || '',
+                osType: image.osType || 'Linux',
+                architecture: image.architecture || 'x86_64',
+                description: image.description || '',
             })
         } else {
             setEditingImage(null)
@@ -107,7 +107,7 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
             const newImage: VmImage = {
                 id: Date.now().toString(),
                 ...formData,
-                size: selectedFile ? `${(selectedFile.size / (1024 * 1024 * 1024)).toFixed(1)} GB` : "0 GB",
+                size: selectedFile ? `${(selectedFile.size / (1024 * 1024)).toFixed(1)} MB` : "0 MB",
                 uploadDate: new Date().toISOString(),
                 status: "available",
                 filePath: selectedFile ? `/images/${selectedFile.name}` : undefined,
@@ -123,8 +123,8 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
     const [rowsPerPage, setRowsPerPage] = useState(10)
     const filteredImages = images.filter(img =>
         img.name.toLowerCase().includes(search.toLowerCase()) ||
-        img.version.toLowerCase().includes(search.toLowerCase()) ||
-        img.description.toLowerCase().includes(search.toLowerCase())
+        img.version?.toLowerCase().includes(search.toLowerCase()) ||
+        img.description?.toLowerCase().includes(search.toLowerCase())
     )
 
     const handleDelete = (id: string) => {
@@ -179,7 +179,8 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
             headerName: '上传日期',
             flex: 1,
             minWidth: 160,
-            valueFormatter: params => dayjs(params.value as string).format('YYYY年M月D日'),
+            valueFormatter: params =>
+                params.value ? dayjs(params.value as string).format('YYYY年M月D日') : '',
         },
         {
             field: 'actions',

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from uuid import uuid4
 import os
 import libvirt
+from dissect.hypervisor import disk
 from contextlib import asynccontextmanager
 
 # ---------------- Libvirt Connection ----------------
@@ -46,6 +47,15 @@ class VmImage(BaseModel):
     pool: str
     size: str
     path: str
+    # 下列字段在 libvirt 的存储卷信息中通常不存在，故设为可选
+    description: Optional[str] = None
+    version: Optional[str] = None
+    osType: Optional[str] = None
+    architecture: Optional[str] = None
+    # 上传日期可近似使用文件的修改时间
+    uploadDate: Optional[str] = None
+    # 镜像状态目前固定为 available，无法直接从 libvirt 获取
+    status: Optional[str] = None
 
 class VCPUInfo(BaseModel):
     count: int
@@ -138,6 +148,39 @@ def _require_conn():
         raise HTTPException(status_code=503, detail="libvirt 未连接")
     return LIBVIRT_CONNECTION
 
+# 尝试使用 dissect.hypervisor 解析镜像文件以获取版本等元数据
+def _get_image_metadata(path: str) -> dict[str, Optional[str]]:
+    meta: dict[str, Optional[str]] = {
+        "version": None,
+        "osType": None,
+        "architecture": None,
+    }
+    ext = os.path.splitext(path)[1].lower()
+    try:
+        if ext == ".qcow2":
+            with open(path, "rb") as fh:
+                img = disk.qcow2.QCow2(fh, backing_file=disk.qcow2.ALLOW_NO_BACKING_FILE)
+                meta["version"] = f"qcow2 v{img.header.version}"
+        elif ext == ".vmdk":
+            with open(path, "rb") as fh:
+                img = disk.vmdk.VMDK(fh)
+                meta["version"] = f"vmdk v{img.header.version}"
+        elif ext == ".vdi":
+            with open(path, "rb") as fh:
+                img = disk.vdi.VDI(fh)
+                meta["version"] = f"vdi v{img.header.version}"
+        elif ext == ".vhdx":
+            with open(path, "rb") as fh:
+                img = disk.vhdx.VHDX(fh)
+                meta["version"] = f"vhdx v{img.header.version}"
+        elif ext == ".vhd":
+            with open(path, "rb") as fh:
+                img = disk.vhd.VHD(fh)
+                meta["version"] = f"vhd v{img.header.version}"
+    except Exception:
+        pass
+    return meta
+
 # 获取所有虚拟机实例
 def fetch_vm_instances() -> List[VmInstance]:
     conn = _require_conn()
@@ -173,14 +216,30 @@ def fetch_vm_images() -> List[VmImage]:
         pool.refresh(0)
         for vol_name in pool.listVolumes():
             vol = pool.storageVolLookupByName(vol_name)
-            size_gb = vol.info()[1] / (1024 ** 3)
+            size_mb = vol.info()[1] / (1024 ** 2)
+            path = vol.path()
+            # 使用文件的修改时间作为上传日期的近似值
+            try:
+                mtime = os.path.getmtime(path)
+                upload_date = datetime.fromtimestamp(mtime).isoformat()
+            except OSError:
+                upload_date = None
+
+            # 通过 dissect.hypervisor 尝试解析镜像文件获取更多元信息
+            meta = _get_image_metadata(path)
+
             images.append(
                 VmImage(
                     id=vol_name,
                     name=vol_name,
                     pool=pool.name(),
-                    size=f"{size_gb:.1f} GB",
-                    path=vol.path(),
+                    size=f"{size_mb:.1f} MB",
+                    path=path,
+                    uploadDate=upload_date,
+                    status="available",
+                    version=meta.get("version"),
+                    osType=meta.get("osType"),
+                    architecture=meta.get("architecture"),
                 )
             )
     return images

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.20.0
 pydantic>=2.0.0
 python-dotenv>=0.20.0
 libvirt-python>=6.0.0
+dissect.hypervisor>=3.18

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,8 @@ const PHP_API_PORT = process.env.PHP_API_PORT || 8000;
 const PHP_API_HOST = process.env.PHP_API_HOST || '127.0.0.1';
 const PHP_TARGET_URL = `http://${PHP_API_HOST}:${PHP_API_PORT}`;
 
+let httpServer;
+
 app.prepare().then(() => {
   let pythonExecutable;
   let canRunPythonBackend = false;
@@ -78,8 +80,17 @@ app.prepare().then(() => {
     });
 
 
-    process.on('SIGINT', cleanupFastApi);
-    process.on('SIGTERM', cleanupFastApi);
+    const shutdown = () => {
+      cleanupFastApi();
+      if (httpServer) {
+        httpServer.close(() => process.exit());
+      } else {
+        process.exit();
+      }
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
     process.on('exit', cleanupFastApi);
   } else {
     console.log('[NodeJS] Python backend startup skipped due to incompatible platform.');
@@ -129,7 +140,7 @@ app.prepare().then(() => {
     }
   });
 
-  const httpServer = createServer((req, res) => {
+  httpServer = createServer((req, res) => {
     if (req.url && req.url.startsWith('/api/vm')) {
       if (canRunPythonBackend) { // Only proxy if backend is supposed to be running
         return apiProxy(req, res, (err) => {


### PR DESCRIPTION
## Summary
- fetch VM image metadata using `dissect.hypervisor`
- store image size in MB
- handle optional fields safely in the UI
- update Python requirements

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68667427f8788320bfef61a548184bf3