### PR TITLE
switch to guestfs for vm image metadata

### DIFF
--- a/src/PYTHON_BACKEND_SETUP.md
+++ b/src/PYTHON_BACKEND_SETUP.md
@@ -79,7 +79,8 @@
         ```bash
         pip install -r src/requirements.txt
         ```
-        这将确保 `fastapi`、`uvicorn`、`pydantic`、`python-dotenv` 以及 `libvirt-python` (如果需要) 等库安装到 `.venv` 虚拟环境中。`server.js` (在Linux/WSL环境下) 会配置为使用此特定虚拟环境中的 Python 解释器。
+        这将确保 `fastapi`、`uvicorn`、`pydantic`、`python-dotenv`、`libvirt-python` 以及 `guestfs` 等库安装到 `.venv` 虚拟环境中。`server.js` (在Linux/WSL环境下) 会配置为使用此特定虚拟环境中的 Python 解释器。
+        `guestfs` 用于在 `fetch_vm_images` 中解析镜像文件的元数据，如版本和架构信息。如果安装 `guestfs` 时提示缺少系统库，请根据发行版安装 `libguestfs` 相关开发包。
 
 4.  **Node.js 服务器依赖项检查 (`http-proxy-middleware`)**:
     主 Node.js 服务器 (`src/server.js`) 使用 `http-proxy-middleware` 将 API 请求代理到 Python 后端。此 Node.js 依赖项应在 `src/package.json` (或项目根目录的 `package.json`) 中列出并已安装。如果缺失，请导航到包含相应 `package.json` 的目录并运行：

--- a/src/PYTHON_BACKEND_SETUP.md
+++ b/src/PYTHON_BACKEND_SETUP.md
@@ -25,8 +25,10 @@
     *   `python` (Windows) 或 `python3` (Linux/macOS 通常) 命令应在您的终端 PATH 中可用。
     *   `pip` (Python 包安装器) 也应可用。
 
-2.  **安装 libvirt-python 依赖项**:
-    要安装 `libvirt-python`，你可以根据你的操作系统选择合适的方式。以下是主流平台的安装方法：
+2.  安装 sudo apt install libguestfs-tools python3-guestfs
+
+3. **安装 libvirt-python 依赖项**
+   要安装 `libvirt-python`，你可以根据你的操作系统选择合适的方式。以下是主流平台的安装方法：
 
     ✅ 通用推荐：使用 pip 安装（适用于大多数 Linux 系统和虚拟环境）
     
@@ -67,7 +69,7 @@
     *   **必须使用虚拟环境**: 为了确保 `server.js` 能够正确启动 Python 后端，您**必须**在项目的**根目录**下创建一个名为 `.venv` 的 Python 虚拟环境，并将所有 Python 依赖项安装到此环境中。
         *   在项目根目录 (与 `src` 文件夹同级的位置) 打开 WSL 终端，然后执行：
             ```bash
-            python3 -m venv .venv
+            python3 -m venv --system-site-packages .venv
             ```
             *(如果您的系统默认 `python` 指向 Python 3，也可以使用 `python -m venv .venv`)*
         *   激活虚拟环境：
@@ -77,7 +79,7 @@
             激活后，您的终端提示符通常会显示 `(.venv)`。
     *   **安装 Python 依赖包**: 激活虚拟环境后，安装 `src/requirements.txt` 中列出的所有依赖项：
         ```bash
-        pip install -r src/requirements.txt
+        pip install -r requirements.txt
         ```
         这将确保 `fastapi`、`uvicorn`、`pydantic`、`python-dotenv`、`libvirt-python` 以及 `guestfs` 等库安装到 `.venv` 虚拟环境中。`server.js` (在Linux/WSL环境下) 会配置为使用此特定虚拟环境中的 Python 解释器。
         `guestfs` 用于在 `fetch_vm_images` 中解析镜像文件的元数据，如版本和架构信息。如果安装 `guestfs` 时提示缺少系统库，请根据发行版安装 `libguestfs` 相关开发包。

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -1,11 +1,22 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
 import {
-    Box, Button, Divider, Menu, MenuItem,
-    Tabs, Tab, TextField, Typography, InputAdornment,
-    Paper, useTheme,
-} from "@mui/material"
+    Box,
+    Button,
+    Divider,
+    Menu,
+    MenuItem,
+    Tabs,
+    Tab,
+    TextField,
+    Typography,
+    InputAdornment,
+    Paper,
+    LinearProgress,
+    Skeleton,
+    useTheme,
+} from "@mui/material";
 import {
     Search as SearchIcon,
     CheckCircle as CheckCircleIcon,
@@ -19,116 +30,226 @@ import {
     DesktopWindows as VncIcon,
     Camera as SnapshotIcon,
     KeyboardArrowDown as ArrowDownIcon,
-} from "@mui/icons-material"
-import { DataGrid, GridColDef } from "@mui/x-data-grid"
-import OverviewPanel from "@/components/vm/OverviewPanel"
-import SnapshotsPanel from "@/components/vm/SnapshotsPanel"
-import StoragePanel from "@/components/vm/StoragePanel"
-import NetworkPanel from "@/components/vm/NetworkPanel"
-import PerformancePanel from "@/components/vm/PerformancePanel"
-import EventsPanel from "@/components/vm/EventsPanel"
+} from "@mui/icons-material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import useSWR from "swr";
+
+import OverviewPanel from "@/components/vm/OverviewPanel";
+import SnapshotsPanel from "@/components/vm/SnapshotsPanel";
+import StoragePanel from "@/components/vm/StoragePanel";
+import NetworkPanel from "@/components/vm/NetworkPanel";
+import PerformancePanel from "@/components/vm/PerformancePanel";
+import EventsPanel from "@/components/vm/EventsPanel";
 
 /* ---------- 类型 ---------- */
 interface VmInstance {
-    id: string
-    name: string
-    hostNode: string      // 宿主机
-    pool: string          // 存储或分组
-    state: "running" | "paused" | "shutoff"
-    vcpu: number
-    vmem: number          // MB
-    ip?: string
-    uptime?: string
+    id: string;
+    name: string;
+    hostNode: string;
+    pool: string;
+    state: "running" | "paused" | "shutoff";
+    vcpu: number;
+    vmem: number; // MB
+    ip?: string;
+    uptime?: string;
 }
 
-/* ---------- 从后端获取虚拟机实例列表 ---------- */
+/* ---------- SWR Hook ---------- */
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+function useVmInstances() {
+    const {
+        data,
+        error,
+        isLoading,
+        isValidating,
+        mutate, // 若后面需要手动刷新可用
+    } = useSWR<VmInstance[]>("/api/vm/instances", fetcher, {
+        // 10 s 内认为数据“新鲜”，避免短时间重复请求
+        dedupingInterval: 10_000,
+        keepPreviousData: true,
+
+        /* 智能轮询：有 pending 状态 ➜ 5 s；全部 running ➜ 30 s */
+        refreshInterval: (latest: VmInstance[] | undefined) => {
+            if (!latest) return 5_000; // 首次
+            const unstable = latest.some((vm) =>
+                ["paused", "shutoff"].includes(vm.state)
+            );
+            return unstable ? 5_000 : 30_000;
+        },
+
+        /* 标签页不可见/后台时不轮询 */
+        refreshWhenHidden: false,
+        /* 聚焦窗口时会自动 revalidate，保留默认 true */
+        revalidateOnFocus: true,
+    });
+
+    return { data, error, isLoading, isValidating };
+}
 
 /* ---------- 状态图标 ---------- */
 function stateIcon(state: VmInstance["state"]) {
     switch (state) {
-        case "running": return <CheckCircleIcon sx={{ fontSize: 16, color: "success.main" }} />
-        case "paused": return <WarningIcon sx={{ fontSize: 16, color: "warning.main" }} />
-        default: return <ErrorIcon sx={{ fontSize: 16, color: "grey.500" }} />
+        case "running":
+            return <CheckCircleIcon sx={{ fontSize: 16, color: "success.main" }} />;
+        case "paused":
+            return <WarningIcon sx={{ fontSize: 16, color: "warning.main" }} />;
+        default:
+            return <ErrorIcon sx={{ fontSize: 16, color: "grey.500" }} />;
     }
 }
 
 export default function VmPage() {
-    const [rows, setRows] = React.useState<VmInstance[]>([])
-    const [current, setCurrent] = React.useState<VmInstance | null>(null)
-    const [search, setSearch] = React.useState("")
-    const [page, setPage] = React.useState(0)
-    const [rowsPerPage, setRowsPerPage] = React.useState(10)
-    const [tab, setTab] = React.useState(0)
-    const [actionAnchor, setActionAnchor] = React.useState<null | HTMLElement>(null)
+    /* ---- SWR 数据 ---- */
+    const { data, isLoading, isValidating } = useVmInstances();
 
-    // 从后端获取虚拟机实例列表
+    /* ---- 本地 UI 状态 ---- */
+    const [current, setCurrent] = React.useState<VmInstance | null>(null);
+    const [search, setSearch] = React.useState("");
+    const [page, setPage] = React.useState(0);
+    const [rowsPerPage, setRowsPerPage] = React.useState(10);
+    const [tab, setTab] = React.useState(0);
+    const [actionAnchor, setActionAnchor] = React.useState<null | HTMLElement>(
+        null
+    );
+
+    /* ---- 选中行同步（数据更新后仍保持同一行对象，避免重绘） ---- */
     React.useEffect(() => {
-        fetch('/api/vm/instances')
-            .then(res => res.json())
-            .then((data: VmInstance[]) => {
-                setRows(data)
-                setCurrent(data[0] ?? null)
-            })
-            .catch(() => {})
-    }, [])
+        if (!data) return;
+        if (current) {
+            const fresh = data.find((d) => d.id === current.id);
+            setCurrent(fresh ?? data[0] ?? null);
+        } else {
+            setCurrent(data[0] ?? null);
+        }
+    }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    /* ----- 列定义 ----- */
-    const columns = React.useMemo<GridColDef[]>(() => [
-        { field: "state", headerName: "", width: 40, renderCell: p => stateIcon(p.row.state) },
-        { field: "name", headerName: "名称", minWidth: 160, flex: 1 },
-        { field: "hostNode", headerName: "宿主机", minWidth: 120 },
-        { field: "pool", headerName: "存储池", minWidth: 120 },
-        { field: "vcpu", headerName: "vCPU", width: 80 },
-        { field: "vmem", headerName: "内存 (MB)", width: 100 },
-        { field: "ip", headerName: "IP", minWidth: 140 },
-        { field: "uptime", headerName: "运行时间", minWidth: 120 },
-    ], [])
+    /* ---- 列定义 ---- */
+    const columns = React.useMemo<GridColDef[]>(
+        () => [
+            {
+                field: "state",
+                headerName: "",
+                width: 40,
+                renderCell: (p) => stateIcon(p.row.state),
+            },
+            { field: "name", headerName: "名称", minWidth: 160, flex: 1 },
+            { field: "hostNode", headerName: "宿主机", minWidth: 120 },
+            { field: "pool", headerName: "存储池", minWidth: 120 },
+            { field: "vcpu", headerName: "vCPU", width: 80 },
+            { field: "vmem", headerName: "内存 (MB)", width: 100 },
+            { field: "ip", headerName: "IP", minWidth: 140 },
+            { field: "uptime", headerName: "运行时间", minWidth: 120 },
+        ],
+        []
+    );
 
     const theme = useTheme();
+
+    /* ---- 行过滤 ---- */
+    const filteredRows = React.useMemo(
+        () =>
+            (data ?? []).filter((r) =>
+                r.name.toLowerCase().includes(search.toLowerCase())
+            ),
+        [data, search]
+    );
+
     return (
         <Box sx={{ p: { xs: 2, sm: 3 } }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-                    <Typography variant="h4" component="h1">虚拟机实例管理</Typography>
+            {/* ---------- 顶栏 ---------- */}
+            <Box
+                sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    mb: 3,
+                    flexWrap: "wrap",
+                    gap: 2,
+                }}
+            >
+                <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+                    <Typography variant="h4">虚拟机实例管理</Typography>
                     <TextField
                         variant="outlined"
                         placeholder="搜索虚拟机..."
                         value={search}
-                        onChange={e => setSearch(e.target.value)}
+                        onChange={(e) => setSearch(e.target.value)}
                         size="small"
-                        InputProps={{ startAdornment: (
-                            <InputAdornment position="start">
-                                <SearchIcon />
-                            </InputAdornment>
-                        )}}
-                        sx={{ width: { xs: '100%', sm: 260 } }}
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <SearchIcon />
+                                </InputAdornment>
+                            ),
+                        }}
+                        sx={{ width: { xs: "100%", sm: 260 } }}
                     />
                 </Box>
             </Box>
 
-            <Box component={Paper} sx={{ boxShadow: 3, height: '50vh', display: 'flex', flexDirection: 'column' }}>
-                <DataGrid
-                    rows={rows.filter(r => r.name.toLowerCase().includes(search.toLowerCase()))}
-                    columns={columns}
-                    density="compact"
-                    pageSizeOptions={[5, 10, 25]}
-                    paginationModel={{ pageSize: rowsPerPage, page }}
-                    onPaginationModelChange={(m) => { setRowsPerPage(m.pageSize); setPage(m.page); }}
-                    onRowClick={p => setCurrent(p.row)}
+            {/* ---------- 列表区域 ---------- */}
+            {isLoading ? (
+                /* === 首次 Skeleton === */
+                <Skeleton variant="rectangular" height={300} sx={{ borderRadius: 1 }} />
+            ) : (
+                <Box
+                    component={Paper}
                     sx={{
-                        height: '100%',
-                        '& .MuiDataGrid-columnHeaders': {
-                            bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[200],
-                        },
+                        boxShadow: 3,
+                        height: "50vh",
+                        display: "flex",
+                        flexDirection: "column",
+                        position: "relative",
                     }}
-                />
-            </Box>
+                >
+                    {/* 细线进度条：仅后台刷新时显示 */}
+                    {isValidating && (
+                        <LinearProgress
+                            sx={{ position: "absolute", top: 0, left: 0, right: 0, zIndex: 2 }}
+                        />
+                    )}
 
-            {/* Details */}
+                    <DataGrid
+                        rows={filteredRows}
+                        columns={columns}
+                        density="compact"
+                        pageSizeOptions={[5, 10, 25]}
+                        paginationModel={{ pageSize: rowsPerPage, page }}
+                        onPaginationModelChange={(m) => {
+                            setRowsPerPage(m.pageSize);
+                            setPage(m.page);
+                        }}
+                        onRowClick={(p) => setCurrent(p.row)}
+                        sx={{
+                            height: "100%",
+                            "& .MuiDataGrid-columnHeaders": {
+                                bgcolor:
+                                    theme.palette.mode === "dark"
+                                        ? theme.palette.grey[800]
+                                        : theme.palette.grey[200],
+                            },
+                        }}
+                    />
+                </Box>
+            )}
+
+            {/* ---------- 详情面板 ---------- */}
             {current && (
-                <Box component={Paper} sx={{ mt: 3, p: 2, display: 'flex', flexDirection: 'column', minHeight: '50vh', boxShadow: 3, overflow: 'auto' }}>
-                    {/* Actions bar */}
-                    <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box
+                    component={Paper}
+                    sx={{
+                        mt: 3,
+                        p: 2,
+                        display: "flex",
+                        flexDirection: "column",
+                        minHeight: "50vh",
+                        boxShadow: 3,
+                        overflow: "auto",
+                    }}
+                >
+                    {/* --- Action Bar --- */}
+                    <Box sx={{ mb: 1, display: "flex", alignItems: "center", gap: 1 }}>
                         {stateIcon(current.state)}
                         <Typography sx={{ mr: 2 }}>{current.name}</Typography>
 
@@ -153,7 +274,7 @@ export default function VmPage() {
                         <Button
                             size="small"
                             variant="outlined"
-                            sx={{ ml: 'auto' }}
+                            sx={{ ml: "auto" }}
                             startIcon={<ConsoleIcon />}
                         >
                             Console
@@ -162,24 +283,31 @@ export default function VmPage() {
                             size="small"
                             variant="outlined"
                             endIcon={<ArrowDownIcon />}
-                            onClick={e => setActionAnchor(e.currentTarget)}
+                            onClick={(e) => setActionAnchor(e.currentTarget)}
                         >
                             More
                         </Button>
                     </Box>
 
-                    {/* Tabs */}
+                    {/* --- Tabs --- */}
                     <Tabs
                         value={tab}
                         onChange={(_, v) => setTab(v)}
-                        sx={{ borderBottom: 1, borderColor: 'divider', pl: 2 }}
+                        sx={{ borderBottom: 1, borderColor: "divider", pl: 2 }}
                     >
-                        {["Overview", "Snapshots", "Storage", "Network", "Performance", "Events"].map(l => (
+                        {[
+                            "Overview",
+                            "Snapshots",
+                            "Storage",
+                            "Network",
+                            "Performance",
+                            "Events",
+                        ].map((l) => (
                             <Tab key={l} label={l.toUpperCase()} />
                         ))}
                     </Tabs>
 
-                    {/* Panels */}
+                    {/* --- Panels --- */}
                     <Box sx={{ flex: 1, p: 2 }}>
                         {tab === 0 && current && <OverviewPanel vmId={current.id} />}
                         {tab === 1 && current && <SnapshotsPanel vmId={current.id} />}
@@ -191,7 +319,7 @@ export default function VmPage() {
                 </Box>
             )}
 
-            {/* --- More Actions Menu --- */}
+            {/* ---------- More Actions Menu ---------- */}
             <Menu
                 anchorEl={actionAnchor}
                 open={Boolean(actionAnchor)}
@@ -208,5 +336,5 @@ export default function VmPage() {
                 </MenuItem>
             </Menu>
         </Box>
-    )
+    );
 }

--- a/src/components/vm/OverviewPanel.tsx
+++ b/src/components/vm/OverviewPanel.tsx
@@ -1,27 +1,37 @@
-import React, { useState, useEffect } from 'react';
+"use client";
+import React from "react";
 import {
-  Alert, Box, CircularProgress, Grid, Stack, Typography, Paper, Skeleton
-} from '@mui/material';
+  Alert,
+  Box,
+  CircularProgress,
+  Grid,
+  Stack,
+  Typography,
+  Paper,
+  Skeleton,
+  LinearProgress,
+} from "@mui/material";
 import {
-  Dns, Memory as MemoryIconMui, Storage as StorageIcon, NetworkCheck
-} from '@mui/icons-material'; // Renamed Memory to MemoryIconMui to avoid conflict
+  Dns,
+  Memory as MemoryIconMui,
+  Storage as StorageIcon,
+  NetworkCheck,
+} from "@mui/icons-material";
+import useSWR from "swr";
 
-
+/* ---------- 类型 ---------- */
 interface OverviewPanelProps {
   vmId: string;
 }
-
 interface VCPUInfo {
   count: number;
   usage_percent: number;
 }
-
 interface VRAMInfo {
   total_mb: number;
   usage_mb: number;
   usage_percent: number;
 }
-
 interface OverviewData {
   status: string;
   uptime: string;
@@ -36,101 +46,241 @@ interface OverviewData {
   network_throughput_mbps: number;
 }
 
+/* ---------- 公用小组件 ---------- */
+const MiniGauge: React.FC<{
+  label: string;
+  value: number;
+  unit?: string;
+  icon?: React.ReactElement;
+  isLoading?: boolean;
+}> = ({ label, value, unit = "%", icon, isLoading }) => (
+    <Paper
+        variant="outlined"
+        sx={{
+          p: 2,
+          textAlign: "center",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+        }}
+    >
+      <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          justifyContent="center"
+          sx={{ mb: 1 }}
+      >
+        {icon}
+        <Typography variant="subtitle2">{label}</Typography>
+      </Stack>
 
-const MiniGauge: React.FC<{label: string; value: number; unit?: string; icon?: React.ReactElement; isLoading?: boolean }> = ({ label, value, unit = '%', icon, isLoading }) => (
-  <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', width: '100%', height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-    <Stack direction="row" spacing={1} alignItems="center" justifyContent="center" sx={{ mb: 1 }}>
-      {icon}
-      <Typography variant="subtitle2" >{label}</Typography>
+      {isLoading ? (
+          <Skeleton
+              variant="circular"
+              width={60}
+              height={60}
+              sx={{ my: 1, mx: "auto" }}
+          />
+      ) : (
+          <CircularProgress
+              variant="determinate"
+              value={unit === "%" ? value : value > 0 ? 100 : 0}
+              size={60}
+              thickness={4}
+              sx={{ my: 1 }}
+          />
+      )}
+
+      {isLoading ? (
+          <Skeleton width="50%" sx={{ mx: "auto" }} />
+      ) : (
+          <Typography variant="h6" display="block">
+            {value.toFixed(1)}
+            {unit}
+          </Typography>
+      )}
+    </Paper>
+);
+
+const KeyValueListItem: React.FC<{
+  label: string;
+  value: string | number | undefined;
+  isLoading?: boolean;
+}> = ({ label, value, isLoading }) => (
+    <Stack
+        direction="row"
+        justifyContent="space-between"
+        sx={{
+          py: 1,
+          borderBottom: "1px solid #eee",
+          "&:last-child": { borderBottom: "none" },
+        }}
+    >
+      <Typography variant="body2" color="text.secondary">
+        {label}:
+      </Typography>
+      {isLoading ? (
+          <Skeleton width="40%" />
+      ) : (
+          <Typography variant="body2" sx={{ textAlign: "right" }}>
+            {value ?? "N/A"}
+          </Typography>
+      )}
     </Stack>
-    {isLoading ? <Skeleton variant="circular" width={60} height={60} sx={{my:1, mx: 'auto'}} /> : <CircularProgress variant="determinate" value={unit === '%' ? value : (value > 0 ? 100: 0) } size={60} thickness={4} sx={{my:1}} />}
-    {isLoading ? <Skeleton width="50%" sx={{mx: 'auto'}} /> : <Typography variant="h6" display="block">{value.toFixed(1)}{unit}</Typography>}
-  </Paper>
 );
 
-const KeyValueListItem: React.FC<{label: string; value: string | number | undefined; isLoading?: boolean}> = ({label, value, isLoading}) => (
-  <Stack direction="row" justifyContent="space-between" sx={{ py: 1, borderBottom: '1px solid #eee', '&:last-child': { borderBottom: 'none'} }}>
-    <Typography variant="body2" color="text.secondary">{label}:</Typography>
-    {isLoading ? <Skeleton width="40%" /> : <Typography variant="body2" sx={{textAlign: 'right'}}>{value ?? 'N/A'}</Typography>}
-  </Stack>
-);
+/* ---------- 主组件 ---------- */
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 export default function OverviewPanel({ vmId }: OverviewPanelProps) {
-  const [overviewData, setOverviewData] = useState<OverviewData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  /* --- SWR 轮询，保留旧数据 --- */
+  const {
+    data,
+    error,
+    isLoading,
+    isValidating, // 后台刷新中
+  } = useSWR<OverviewData>(`/api/vm/${vmId}/overview`, fetcher, {
+    refreshInterval: 5000, // 5 s 轮询
+    keepPreviousData: true,
+    refreshWhenHidden: false, // 标签页不可见时暂停
+    dedupingInterval: 5000, // 与 refreshInterval 对齐
+  });
 
-  useEffect(() => {
-    const fetchOverviewData = async () => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const response = await fetch(`/api/vm/${vmId}/overview`);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch overview data: ${response.status} ${response.statusText}`);
-        }
-        const data: OverviewData = await response.json();
-        setOverviewData(data);
-      } catch (err: any) {
-        setError(err.message || 'An unknown error occurred.');
-        setOverviewData(null); // Clear data on error
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchOverviewData(); // Initial fetch
-    const intervalId = setInterval(fetchOverviewData, 5000); // Refresh every 5 seconds
-
-    return () => clearInterval(intervalId); // Cleanup interval on component unmount
-  }, []);
+  const initialLoading = isLoading && !data; // 只在首屏显示 Skeleton
+  const overviewData = data ?? null;
 
   if (error) {
-    return <Alert severity="error" sx={{m:2}}>Error loading overview: {error}</Alert>;
+    return (
+        <Alert severity="error" sx={{ m: 2 }}>
+          Error loading overview: {(error as any).message || "unknown"}
+        </Alert>
+    );
   }
 
   return (
-    <Stack spacing={2.5} sx={{p: 0.5}}>
-      <Grid container spacing={2.5}>
-        {/* Left Column: Basic Info */}
-        <Grid item xs={12} md={5}>
-          <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
-            <Typography variant="h6" sx={{ mb: 1.5, borderBottom: '1px solid #ddd', pb:1 }}>基本配置</Typography>
-            <Stack spacing={0}>
-              <KeyValueListItem label="Status" value={overviewData?.status} isLoading={isLoading} />
-              <KeyValueListItem label="Host Node" value={overviewData?.hostNode} isLoading={isLoading} />
-              <KeyValueListItem label="Pool" value={overviewData?.pool} isLoading={isLoading} />
-              <KeyValueListItem label="vCPU Count" value={overviewData?.vcpu?.count} isLoading={isLoading} />
-              <KeyValueListItem label="vRAM Total" value={overviewData?.vram?.total_mb !== undefined ? `${overviewData.vram.total_mb} MB` : undefined} isLoading={isLoading} />
-              <KeyValueListItem label="Boot Source" value={overviewData?.bootSource} isLoading={isLoading} />
-              <KeyValueListItem label="UUID" value={overviewData?.uuid} isLoading={isLoading} />
-              <KeyValueListItem label="IP Address" value={overviewData?.ipAddress} isLoading={isLoading} />
-              <KeyValueListItem label="Uptime" value={overviewData?.uptime} isLoading={isLoading} />
-            </Stack>
-          </Paper>
-        </Grid>
+      <Stack spacing={2.5} sx={{ p: 0.5, position: "relative" }}>
+        {/* 细线进度条：后台刷新时出现，不影响内容 */}
+        {isValidating && (
+            <LinearProgress
+                sx={{ position: "absolute", top: 0, left: 0, right: 0, zIndex: 2 }}
+            />
+        )}
 
-        {/* Right Column: Real-time Usage */}
-        <Grid item xs={12} md={7}>
-           <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
-            <Typography variant="h6" sx={{ mb: 1.5, borderBottom: '1px solid #ddd', pb:1 }}>实时用量</Typography>
-            <Grid container spacing={2} alignItems="stretch">
-              <Grid item xs={6} sm={3}>
-                <MiniGauge label="CPU" value={overviewData?.vcpu?.usage_percent ?? 0} icon={<Dns fontSize="small" />} isLoading={isLoading} />
+        <Grid container spacing={2.5}>
+          {/* ---------- 左侧基本信息 ---------- */}
+          <Grid item xs={12} md={5}>
+            <Paper variant="outlined" sx={{ p: 2, height: "100%" }}>
+              <Typography
+                  variant="h6"
+                  sx={{ mb: 1.5, borderBottom: "1px solid #ddd", pb: 1 }}
+              >
+                基本配置
+              </Typography>
+              <Stack spacing={0}>
+                <KeyValueListItem
+                    label="Status"
+                    value={overviewData?.status}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="Host Node"
+                    value={overviewData?.hostNode}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="Pool"
+                    value={overviewData?.pool}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="vCPU Count"
+                    value={overviewData?.vcpu?.count}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="vRAM Total"
+                    value={
+                      overviewData?.vram?.total_mb !== undefined
+                          ? `${overviewData.vram.total_mb} MB`
+                          : undefined
+                    }
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="Boot Source"
+                    value={overviewData?.bootSource}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="UUID"
+                    value={overviewData?.uuid}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="IP Address"
+                    value={overviewData?.ipAddress}
+                    isLoading={initialLoading}
+                />
+                <KeyValueListItem
+                    label="Uptime"
+                    value={overviewData?.uptime}
+                    isLoading={initialLoading}
+                />
+              </Stack>
+            </Paper>
+          </Grid>
+
+          {/* ---------- 右侧实时用量 ---------- */}
+          <Grid item xs={12} md={7}>
+            <Paper variant="outlined" sx={{ p: 2, height: "100%" }}>
+              <Typography
+                  variant="h6"
+                  sx={{ mb: 1.5, borderBottom: "1px solid #ddd", pb: 1 }}
+              >
+                实时用量
+              </Typography>
+              <Grid container spacing={2} alignItems="stretch">
+                <Grid item xs={6} sm={3}>
+                  <MiniGauge
+                      label="CPU"
+                      value={overviewData?.vcpu?.usage_percent ?? 0}
+                      icon={<Dns fontSize="small" />}
+                      isLoading={initialLoading}
+                  />
+                </Grid>
+                <Grid item xs={6} sm={3}>
+                  <MiniGauge
+                      label="Memory"
+                      value={overviewData?.vram?.usage_percent ?? 0}
+                      icon={<MemoryIconMui fontSize="small" />}
+                      isLoading={initialLoading}
+                  />
+                </Grid>
+                <Grid item xs={6} sm={3}>
+                  <MiniGauge
+                      label="Disk R/W"
+                      value={overviewData?.disks_rw_mbps ?? 0}
+                      unit="MB/s"
+                      icon={<StorageIcon fontSize="small" />}
+                      isLoading={initialLoading}
+                  />
+                </Grid>
+                <Grid item xs={6} sm={3}>
+                  <MiniGauge
+                      label="Net Throughput"
+                      value={overviewData?.network_throughput_mbps ?? 0}
+                      unit="Mbps"
+                      icon={<NetworkCheck fontSize="small" />}
+                      isLoading={initialLoading}
+                  />
+                </Grid>
               </Grid>
-              <Grid item xs={6} sm={3}>
-                <MiniGauge label="Memory" value={overviewData?.vram?.usage_percent ?? 0} icon={<MemoryIconMui fontSize="small" />} isLoading={isLoading} />
-              </Grid>
-              <Grid item xs={6} sm={3}>
-                <MiniGauge label="Disk R/W" value={overviewData?.disks_rw_mbps ?? 0} unit="MB/s" icon={<StorageIcon fontSize="small" />} isLoading={isLoading} />
-              </Grid>
-              <Grid item xs={6} sm={3}>
-                <MiniGauge label="Net Throughput" value={overviewData?.network_throughput_mbps ?? 0} unit="Mbps" icon={<NetworkCheck fontSize="small" />} isLoading={isLoading} />
-              </Grid>
-            </Grid>
-          </Paper>
+            </Paper>
+          </Grid>
         </Grid>
-      </Grid>
-    </Stack>
+      </Stack>
   );
 }

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from uuid import uuid4
 import os
 import libvirt
-from dissect.hypervisor import disk
+import guestfs
 from contextlib import asynccontextmanager
 
 # ---------------- Libvirt Connection ----------------
@@ -148,37 +148,33 @@ def _require_conn():
         raise HTTPException(status_code=503, detail="libvirt 未连接")
     return LIBVIRT_CONNECTION
 
-# 尝试使用 dissect.hypervisor 解析镜像文件以获取版本等元数据
+# 使用 libguestfs 解析镜像文件以获取版本等元数据
 def _get_image_metadata(path: str) -> dict[str, Optional[str]]:
     meta: dict[str, Optional[str]] = {
         "version": None,
         "osType": None,
         "architecture": None,
     }
-    ext = os.path.splitext(path)[1].lower()
+    g = guestfs.GuestFS(python_return_dict=True)
     try:
-        if ext == ".qcow2":
-            with open(path, "rb") as fh:
-                img = disk.qcow2.QCow2(fh, backing_file=disk.qcow2.ALLOW_NO_BACKING_FILE)
-                meta["version"] = f"qcow2 v{img.header.version}"
-        elif ext == ".vmdk":
-            with open(path, "rb") as fh:
-                img = disk.vmdk.VMDK(fh)
-                meta["version"] = f"vmdk v{img.header.version}"
-        elif ext == ".vdi":
-            with open(path, "rb") as fh:
-                img = disk.vdi.VDI(fh)
-                meta["version"] = f"vdi v{img.header.version}"
-        elif ext == ".vhdx":
-            with open(path, "rb") as fh:
-                img = disk.vhdx.VHDX(fh)
-                meta["version"] = f"vhdx v{img.header.version}"
-        elif ext == ".vhd":
-            with open(path, "rb") as fh:
-                img = disk.vhd.VHD(fh)
-                meta["version"] = f"vhd v{img.header.version}"
+        g.add_drive_opts(path, readonly=1)
+        g.launch()
+        roots = g.inspect_os()
+        if roots:
+            root = roots[0]
+            distro = g.inspect_get_distro(root)
+            major = g.inspect_get_major_version(root)
+            minor = g.inspect_get_minor_version(root)
+            meta["version"] = f"{distro} {major}.{minor}"
+            meta["osType"] = g.inspect_get_type(root)
+            meta["architecture"] = g.inspect_get_arch(root)
     except Exception:
         pass
+    finally:
+        try:
+            g.close()
+        except Exception:
+            pass
     return meta
 
 # 获取所有虚拟机实例
@@ -225,7 +221,7 @@ def fetch_vm_images() -> List[VmImage]:
             except OSError:
                 upload_date = None
 
-            # 通过 dissect.hypervisor 尝试解析镜像文件获取更多元信息
+            # 使用 guestfs 解析镜像文件获取更多元信息
             meta = _get_image_metadata(path)
 
             images.append(

--- a/src/main.py
+++ b/src/main.py
@@ -157,7 +157,7 @@ def _get_image_metadata(path: str) -> dict[str, Optional[str]]:
     }
     g = guestfs.GuestFS(python_return_dict=True)
     try:
-        g.add_drive_opts(path, readonly=1)
+        g.add_drive_opts(path, readonly=True)
         g.launch()
         roots = g.inspect_os()
         if roots:
@@ -209,6 +209,8 @@ def fetch_vm_images() -> List[VmImage]:
     conn = _require_conn()
     images: List[VmImage] = []
     for pool in conn.listAllStoragePools():
+        if pool.name() != "default":          # 只看 default 池
+            continue
         pool.refresh(0)
         for vol_name in pool.listVolumes():
             vol = pool.storageVolLookupByName(vol_name)

--- a/src/package.json
+++ b/src/package.json
@@ -33,6 +33,7 @@
     "react-rnd": "^10.5.2",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
+    "swr": "^2.3.4",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,4 +3,4 @@ uvicorn[standard]>=0.20.0
 pydantic>=2.0.0
 python-dotenv>=0.20.0
 libvirt-python>=6.0.0
-dissect.hypervisor>=3.18
+guestfs>=0.0.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,4 +3,3 @@ uvicorn[standard]>=0.20.0
 pydantic>=2.0.0
 python-dotenv>=0.20.0
 libvirt-python>=6.0.0
-guestfs>=0.0.1


### PR DESCRIPTION
## Summary
- use `guestfs` instead of dissect.hypervisor for extracting metadata in `fetch_vm_images`
- require `guestfs` in Python dependencies
- document the new requirement in backend setup

## Testing
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68669b808438832081b6f3baa67605c0