### PR TITLE
Add VM creation support

### DIFF
--- a/src/GUACAMOLE_SETUP.md
+++ b/src/GUACAMOLE_SETUP.md
@@ -1,0 +1,97 @@
+# Guacamole 安装与配置指南
+
+本文档描述如何在本服务器上部署 [Apache Guacamole](https://guacamole.apache.org/) 并使 `src/main.py` 中的 `/api/vms/create` 接口能够自动创建 SSH、VNC 与 RDP 连接。
+
+## 1. 安装依赖
+
+以 Ubuntu 22.04 为例，首先安装构建 guacd 所需的库及 Tomcat9：
+
+```bash
+sudo apt update
+sudo apt install -y build-essential libcairo2-dev libjpeg-turbo8-dev \
+  libpng-dev libtool-bin libossp-uuid-dev libvncserver-dev \
+  freerdp2-dev libpango1.0-dev libssh2-1-dev libtelnet-dev \
+  libwebsockets-dev libpulse-dev libvorbis-dev libwebp-dev \
+  tomcat9 tomcat9-admin
+```
+
+接下来下载并编译 `guacamole-server`：
+
+```bash
+wget https://downloads.apache.org/guacamole/1.5.4/source/guacamole-server-1.5.4.tar.gz
+ tar -xf guacamole-server-1.5.4.tar.gz
+ cd guacamole-server-1.5.4
+ ./configure --with-init-dir=/etc/init.d
+ make -j$(nproc)
+ sudo make install
+ sudo ldconfig
+ sudo systemctl enable guacd
+ sudo systemctl start guacd
+```
+
+## 2. 部署 Web 应用
+
+下载 Guacamole Web 应用并放入 Tomcat 的 `webapps` 目录：
+
+```bash
+wget https://downloads.apache.org/guacamole/1.5.4/binary/guacamole-1.5.4.war \
+  -O /var/lib/tomcat9/webapps/guacamole.war
+sudo systemctl restart tomcat9
+```
+
+创建配置目录 `/etc/guacamole` 并添加 `guacamole.properties`：
+
+```bash
+sudo mkdir -p /etc/guacamole
+cat <<'_EOF' | sudo tee /etc/guacamole/guacamole.properties
+# guacd 连接信息
+ guacd-hostname: localhost
+ guacd-port: 4822
+_EOF
+```
+
+将该目录链接到 Tomcat：
+
+```bash
+sudo ln -s /etc/guacamole /var/lib/tomcat9/.guacamole
+```
+
+## 3. 创建登录账户
+
+为了让后端调用 REST API，需要在 `user-mapping.xml` 中定义至少一个用户：
+
+```bash
+cat <<'_EOF' | sudo tee /etc/guacamole/user-mapping.xml
+<user-mapping>
+    <authorize username="guacadmin" password="guacpass">
+        <connection name="placeholder" protocol="vnc" />
+    </authorize>
+</user-mapping>
+_EOF
+sudo systemctl restart tomcat9
+```
+
+登录地址为 `http://<服务器IP>:8080/guacamole`，使用上述用户名和密码即可登录。
+
+## 4. 确保名称解析
+
+`/api/vms/create` 会在 Guacamole 中生成指向主机名 `hypervisor` 的连接，请确保在运行 Guacamole 的服务器上能解析此主机名，例如在 `/etc/hosts` 中加入：
+
+```
+127.0.0.1   hypervisor
+```
+
+或将其指向实际的虚拟化宿主机 IP。
+
+## 5. 测试 REST API
+
+部署完成后，可使用以下命令测试登录及创建连接是否正常：
+
+```bash
+curl -X POST "http://<服务器IP>:8080/guacamole/api/tokens" \
+     -d "username=guacadmin" -d "password=guacpass"
+```
+
+返回 JSON 中应包含 `authToken`。随后即可按照 `src/main.py` 中的逻辑创建 SSH、VNC、RDP 连接。
+
+完成以上步骤后，前端在调用 `/api/vms/create` 时填写相同的 Guacamole URL 与凭据，即可在 Guacamole 中自动生成对应连接。

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+import * as Guacamole from 'guacamole-common-js'
+
+export default function GuacPage() {
+  const params = useSearchParams();
+  const url = params.get('url') || '';
+  const token = params.get('token') || '';
+  const ds = params.get('ds') || '';
+  const id = params.get('id') || '';
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current || !url || !token || !id || !ds) return;
+    const ws = url.replace(/^http/, 'ws') + '/websocket-tunnel?token=' + token;
+    const tunnel = new Guacamole.WebSocketTunnel(ws);
+    const client = new Guacamole.Client(tunnel);
+    ref.current.innerHTML = '';
+    ref.current.appendChild(client.getDisplay().getElement());
+    client.connect(`token=${token}&connection=${id}&GUAC_DATA_SOURCE=${ds}`);
+    const disconnect = () => client.disconnect();
+    window.addEventListener('beforeunload', disconnect);
+    return () => {
+      window.removeEventListener('beforeunload', disconnect);
+      client.disconnect();
+    };
+  }, [url, token, ds, id]);
+
+  return <div ref={ref} style={{width:'100vw',height:'100vh',background:'#000'}}/>;
+}

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -26,13 +26,14 @@ import {
     Add as AddIcon,
     Edit as EditIcon,
     Delete as DeleteIcon,
-    Visibility as ViewIcon,
+    PlayArrow as StartIcon,
     CloudUpload as UploadIcon,
     Computer as ComputerIcon,
     Search as SearchIcon,
 } from "@mui/icons-material"
 import { DataGrid, GridColDef } from "@mui/x-data-grid"
 import dayjs from "dayjs"
+import CreateVmModal from "@/components/vm/CreateVmModal"
 
 interface VmImage {
     id: string
@@ -51,6 +52,7 @@ const VmImageManagementPage: React.FC = () => {
     const [images, setImages] = useState<VmImage[]>([])
     const [openDialog, setOpenDialog] = useState(false)
     const [editingImage, setEditingImage] = useState<VmImage | null>(null)
+    const [createModalImage, setCreateModalImage] = useState<string | null>(null)
     const [formData, setFormData] = useState({
         name: "",
         version: "",
@@ -96,6 +98,10 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
         setOpenDialog(false)
         setEditingImage(null)
         setSelectedFile(null)
+    }
+
+    const handleStart = (image: VmImage) => {
+        setCreateModalImage(image.filePath || (image as any).path || image.name)
     }
 
     const handleSave = () => {
@@ -189,9 +195,9 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
             width: 140,
             renderCell: params => (
                 <Box>
-                    <Tooltip title="查看详情">
-                        <IconButton size="small">
-                            <ViewIcon />
+                    <Tooltip title="启动">
+                        <IconButton size="small" onClick={() => handleStart(params.row)}>
+                            <StartIcon color="success" />
                         </IconButton>
                     </Tooltip>
                     <Tooltip title="编辑">
@@ -321,6 +327,11 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
                     </Button>
                 </DialogActions>
             </Dialog>
+            <CreateVmModal
+                open={Boolean(createModalImage)}
+                onClose={() => setCreateModalImage(null)}
+                fixedImage={createModalImage || undefined}
+            />
         </Box>
     )
 }

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -31,6 +31,8 @@ import {
     PowerSettingsNew as ForceOffIcon,
     Visibility as ConsoleIcon,
     DesktopWindows as VncIcon,
+    Terminal as SshIcon,
+    LaptopWindows as RdpIcon,
     Camera as SnapshotIcon,
     KeyboardArrowDown as ArrowDownIcon,
     AddCircleOutline as AddIcon,
@@ -188,6 +190,37 @@ export default function VmPage() {
         } finally {
             setActionLoading(false);
         }
+    };
+
+    const getGuacCreds = async () => {
+        let url = localStorage.getItem('guac_url') || '';
+        let user = localStorage.getItem('guac_user') || '';
+        let pass = localStorage.getItem('guac_pass') || '';
+        if (!url) url = prompt('Guacamole URL', 'http://localhost:8080/guacamole') || '';
+        if (!user) user = prompt('Guacamole Username', '') || '';
+        if (!pass) pass = prompt('Guacamole Password', '') || '';
+        localStorage.setItem('guac_url', url);
+        localStorage.setItem('guac_user', user);
+        localStorage.setItem('guac_pass', pass);
+        return { url, user, pass };
+    };
+
+    const handleGuac = async (proto: 'ssh' | 'rdp' | 'vnc') => {
+        if (!current) return;
+        const { url, user, pass } = await getGuacCreds();
+        try {
+            const q = new URLSearchParams({ url, username: user, password: pass }).toString();
+            const res = await fetch(`/api/vms/${current.name}/guac?${q}`);
+            if (!res.ok) throw new Error('Guacamole request failed');
+            const data = await res.json();
+            const id = data.connections?.[proto];
+            if (!id) throw new Error('Connection not found');
+            const dest = `/guac?url=${encodeURIComponent(url)}&token=${encodeURIComponent(data.token)}&ds=${encodeURIComponent(data.ds)}&id=${encodeURIComponent(id)}`;
+            window.open(dest, '_blank');
+        } catch (e: any) {
+            alert(e.message || 'Failed to open connection');
+        }
+        setActionAnchor(null);
     };
 
     return (
@@ -400,9 +433,17 @@ export default function VmPage() {
                     创建快照
                 </MenuItem>
                 <Divider />
-                <MenuItem onClick={() => setActionAnchor(null)}>
+                <MenuItem onClick={() => handleGuac('ssh')}>
+                    <SshIcon fontSize="small" sx={{ mr: 1 }} />
+                    SSH
+                </MenuItem>
+                <MenuItem onClick={() => handleGuac('rdp')}>
+                    <RdpIcon fontSize="small" sx={{ mr: 1 }} />
+                    RDP
+                </MenuItem>
+                <MenuItem onClick={() => handleGuac('vnc')}>
                     <VncIcon fontSize="small" sx={{ mr: 1 }} />
-                    VNC / SPICE 控制台
+                    VNC 控制台
                 </MenuItem>
             </Menu>
             <Backdrop open={actionLoading} sx={{ zIndex: theme.zIndex.modal + 1 }}>

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -33,6 +33,7 @@ import {
     DesktopWindows as VncIcon,
     Camera as SnapshotIcon,
     KeyboardArrowDown as ArrowDownIcon,
+    AddCircleOutline as AddIcon,
 } from "@mui/icons-material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import useSWR, { mutate as globalMutate } from "swr";
@@ -42,6 +43,7 @@ import SnapshotsPanel from "@/components/vm/SnapshotsPanel";
 import StoragePanel from "@/components/vm/StoragePanel";
 import NetworkPanel from "@/components/vm/NetworkPanel";
 import EventsPanel from "@/components/vm/EventsPanel";
+import CreateVmModal from "@/components/vm/CreateVmModal";
 
 /* ---------- 类型 ---------- */
 interface VmInstance {
@@ -118,6 +120,7 @@ export default function VmPage() {
         null
     );
     const [actionLoading, setActionLoading] = React.useState(false);
+    const [createOpen, setCreateOpen] = React.useState(false);
 
     /* ---- 选中行同步（数据更新后仍保持同一行对象，避免重绘） ---- */
     React.useEffect(() => {
@@ -218,6 +221,13 @@ export default function VmPage() {
                         sx={{ width: { xs: "100%", sm: 260 } }}
                     />
                 </Box>
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => setCreateOpen(true)}
+                >
+                    创建实例
+                </Button>
             </Box>
 
             {/* ---------- 列表区域 ---------- */}
@@ -398,6 +408,7 @@ export default function VmPage() {
             <Backdrop open={actionLoading} sx={{ zIndex: theme.zIndex.modal + 1 }}>
                 <CircularProgress color="inherit" />
             </Backdrop>
+            <CreateVmModal open={createOpen} onClose={() => setCreateOpen(false)} onCreated={() => mutate()} />
         </Box>
     );
 }

--- a/src/components/vm/CreateVmModal.tsx
+++ b/src/components/vm/CreateVmModal.tsx
@@ -1,0 +1,137 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem
+} from "@mui/material";
+
+interface VmImage {
+  id: string;
+  name: string;
+  path: string;
+}
+
+interface CreateVmModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+  fixedImage?: string;
+}
+
+export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: CreateVmModalProps) {
+  const [images, setImages] = useState<VmImage[]>([]);
+  const [form, setForm] = useState({
+    vm_name: "",
+    base_image: "",
+    memory: 2048,
+    vcpus: 2,
+    disk_gb: 20,
+    ssh_key: "",
+    admin_password: "",
+    static_ip: "",
+    guacamole: { url: "", username: "", password: "", folder_id: "ROOT" }
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (fixedImage) {
+      setForm(f => ({ ...f, base_image: fixedImage }));
+      setImages([]);
+    } else {
+      fetch("/api/vms/images")
+        .then(res => res.json())
+        .then(data => setImages(data));
+    }
+  }, [open, fixedImage]);
+
+  const resetState = () => {
+    setForm({
+      vm_name: "",
+      base_image: fixedImage || "",
+      memory: 2048,
+      vcpus: 2,
+      disk_gb: 20,
+      ssh_key: "",
+      admin_password: "",
+      static_ip: "",
+      guacamole: { url: "", username: "", password: "", folder_id: "ROOT" }
+    });
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    await fetch("/api/vms/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(form)
+    });
+    onCreated?.();
+    handleClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>创建虚拟机实例</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {fixedImage ? (
+            <TextField label="镜像" value={form.base_image} fullWidth disabled />
+          ) : (
+            <FormControl fullWidth>
+              <InputLabel id="img-label">镜像</InputLabel>
+              <Select
+                labelId="img-label"
+                value={form.base_image}
+                label="镜像"
+                onChange={e => setForm(f => ({ ...f, base_image: e.target.value }))}
+              >
+                {images.map(img => (
+                  <MenuItem key={img.id} value={img.path}>{img.name}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          <TextField label="实例名称" value={form.vm_name}
+            onChange={e => setForm(f => ({ ...f, vm_name: e.target.value }))} fullWidth />
+          <TextField label="内存 (MB)" type="number" value={form.memory}
+            onChange={e => setForm(f => ({ ...f, memory: Number(e.target.value) }))} fullWidth />
+          <TextField label="vCPU" type="number" value={form.vcpus}
+            onChange={e => setForm(f => ({ ...f, vcpus: Number(e.target.value) }))} fullWidth />
+          <TextField label="磁盘 (GB)" type="number" value={form.disk_gb}
+            onChange={e => setForm(f => ({ ...f, disk_gb: Number(e.target.value) }))} fullWidth />
+          <TextField label="SSH 公钥" value={form.ssh_key}
+            onChange={e => setForm(f => ({ ...f, ssh_key: e.target.value }))} fullWidth multiline rows={2} />
+          <TextField label="管理员密码 (Windows)" type="password" value={form.admin_password}
+            onChange={e => setForm(f => ({ ...f, admin_password: e.target.value }))} fullWidth />
+          <TextField label="静态 IP" value={form.static_ip}
+            onChange={e => setForm(f => ({ ...f, static_ip: e.target.value }))} fullWidth />
+          <TextField label="Guacamole URL" value={form.guacamole.url}
+            onChange={e => setForm(f => ({ ...f, guacamole: { ...f.guacamole, url: e.target.value } }))} fullWidth />
+          <TextField label="Guacamole 用户名" value={form.guacamole.username}
+            onChange={e => setForm(f => ({ ...f, guacamole: { ...f.guacamole, username: e.target.value } }))} fullWidth />
+          <TextField label="Guacamole 密码" type="password" value={form.guacamole.password}
+            onChange={e => setForm(f => ({ ...f, guacamole: { ...f.guacamole, password: e.target.value } }))} fullWidth />
+          <TextField label="Guacamole Folder ID" value={form.guacamole.folder_id}
+            onChange={e => setForm(f => ({ ...f, guacamole: { ...f.guacamole, folder_id: e.target.value } }))} fullWidth />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>取消</Button>
+        <Button variant="contained" onClick={handleSubmit}>创建</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,2 +1,3 @@
 declare module '*.css';
 
+declare module 'guacamole-common-js';

--- a/src/main.py
+++ b/src/main.py
@@ -3,10 +3,20 @@ from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 from uuid import uuid4
+import uuid
 import os
 import time
+import textwrap
+import json
+import re
 import libvirt
 import guestfs
+import requests
+from virtinst import Guest
+from virtinst.device.disk import DeviceDisk
+from virtinst.device.interface import DeviceInterface
+from virtinst.device.cloudinit import DeviceCloudInit
+from virtinst.device.graphics import DeviceGraphics
 from contextlib import asynccontextmanager
 
 # ---------------- Libvirt Connection ----------------
@@ -143,6 +153,24 @@ class EventLog(BaseModel):
     message: str
     details: Optional[Dict[str, Any]] = None
 
+# ----- VM Creation Models -----
+class GuacInfo(BaseModel):
+    url: str
+    username: str
+    password: str
+    folder_id: Optional[str] = "ROOT"
+
+class VMRequest(BaseModel):
+    vm_name: Optional[str] = None
+    base_image: str
+    memory: int = 2048
+    vcpus: int = 2
+    disk_gb: int = 20
+    ssh_key: Optional[str] = None
+    admin_password: Optional[str] = None
+    static_ip: Optional[str] = None
+    guacamole: GuacInfo
+
 # ---------------- Helper Functions ----------------
 def _require_conn():
     if not LIBVIRT_CONNECTION:
@@ -255,6 +283,52 @@ def _wait_for_state(dom, target_code: int, timeout: int = 30) -> bool:
         time.sleep(1)
     return False
 
+# ----- VM Creation Helpers -----
+POOL_DIR = "/var/lib/libvirt/images"
+VIRTIO_ISO = "/usr/share/virtio-win/virtio-win.iso"
+
+def detect_os(img_path: str) -> str:
+    g = guestfs.GuestFS(python_return_dict=True)
+    g.add_drive_opts(img_path, readonly=1)
+    g.launch()
+    roots = g.inspect_os()
+    if not roots:
+        raise ValueError("Cannot detect guest OS")
+    return g.inspect_get_type(roots[0])
+
+def gen_mac(seed: str) -> str:
+    h = uuid.uuid5(uuid.NAMESPACE_DNS, seed).hex
+    return "02:" + ":".join(h[i:i+2] for i in range(0, 10, 2))
+
+def parse_vnc_port(xml: str) -> int | None:
+    m = re.search(r"<graphics[^>]*type='vnc'[^>]*port='(\d+)'", xml)
+    return int(m.group(1)) if m else None
+
+def guac_login(url: str, username: str, password: str) -> tuple[str, str]:
+    r = requests.post(f"{url}/api/tokens", data={"username": username, "password": password})
+    if not r.ok:
+        raise RuntimeError("Guacamole auth failed")
+    data = r.json()
+    return data["authToken"], next(iter(data["dataSource"]))
+
+def guac_create_conn(url: str, token: str, ds: str, name: str, proto: str, params: dict, parent: str | None):
+    body = {
+        "name": name,
+        "protocol": proto,
+        "parameters": params,
+        "attributes": {"max-connections": "5", "max-connections-per-user": "2"},
+    }
+    r = requests.post(f"{url}/api/session/data/{ds}/connections", params={"token": token}, json=body)
+    if not r.ok:
+        raise RuntimeError("create connection failed")
+    conn_id = r.json()
+    if parent and parent != "ROOT":
+        requests.post(
+            f"{url}/api/session/data/{ds}/connectionGroups/{parent}/connections/{conn_id}",
+            params={"token": token},
+        )
+    return conn_id
+
 # ---------------- API Endpoints ----------------
 @app.get("/api/vms", response_model=List[VmInstance])
 def list_vms():
@@ -263,6 +337,121 @@ def list_vms():
 @app.get("/api/vms/images", response_model=List[VmImage])
 def list_vm_images():
     return fetch_vm_images()
+
+@app.post("/api/vms/create")
+def create_vm(req: VMRequest):
+    vm_name = req.vm_name or f"vm-{uuid.uuid4().hex[:8]}"
+    mac = gen_mac(vm_name)
+
+    guest_os = detect_os(req.base_image)
+    conn = _require_conn()
+    g = Guest(conn)
+    g.name, g.memory, g.vcpus = vm_name, req.memory, req.vcpus
+    g.os_type = "hvm"
+    g.os_variant = "ubuntu24.04" if guest_os == "linux" else "win10"
+
+    overlay = f"{POOL_DIR}/{vm_name}.qcow2"
+    d = DeviceDisk(g)
+    d.source_file = overlay
+    d.backing_store = req.base_image
+    d.driver_type = "qcow2"
+    d.size = req.disk_gb
+    d.bus, d.create = "virtio", True
+    g.devices.append(d)
+
+    iface = DeviceInterface(g)
+    iface.type = DeviceInterface.TYPE_USER
+    iface.hostfwd = [
+        "tcp::2222-:22",
+        "tcp::33389-:3389",
+    ]
+    iface.mac_address = mac
+    g.devices.append(iface)
+
+    if guest_os == "linux":
+        user_data = textwrap.dedent(f"""\
+            #cloud-config
+            hostname: {vm_name}
+            users:
+              - default
+              - name: ubuntu
+                sudo: ALL=(ALL) NOPASSWD:ALL
+                ssh_authorized_keys:
+                  - {req.ssh_key or ''}
+        """)
+    else:
+        if not req.admin_password:
+            raise HTTPException(422, "Windows VM requires admin_password")
+        user_data = textwrap.dedent(f"""\
+            #cloud-config
+            password: {req.admin_password}
+            username: Administrator
+            runcmd:
+              - powershell -Command "Set-ItemProperty -Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' -Name fDenyTSConnections -Value 0"
+              - powershell -Command "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
+        """)
+
+    ci = DeviceCloudInit(g)
+    ci.user_data = user_data
+    ci.disable = True
+    g.devices.append(ci)
+
+    if guest_os == "windows":
+        drv = DeviceDisk(g)
+        drv.device = DeviceDisk.DEVICE_CDROM
+        drv.read_only = True
+        drv.source_file = VIRTIO_ISO
+        drv.bus = "sata"
+        g.devices.append(drv)
+
+    vnc = DeviceGraphics(g)
+    vnc.type, vnc.port, vnc.listen = "vnc", -1, "0.0.0.0"
+    g.devices.append(vnc)
+
+    dom_xml = g.get_xml_config()
+    dom = conn.defineXML(dom_xml)
+    dom.create()
+    vnc_port = parse_vnc_port(dom.XMLDesc()) or 5900
+
+    try:
+        token, ds = guac_login(
+            req.guacamole.url, req.guacamole.username, req.guacamole.password
+        )
+
+        if guest_os == "linux":
+            guac_create_conn(
+                req.guacamole.url,
+                token,
+                ds,
+                name=vm_name + "-ssh",
+                proto="ssh",
+                params={"hostname": "hypervisor", "port": "2222", "username": "ubuntu"},
+                parent=req.guacamole.folder_id,
+            )
+        else:
+            guac_create_conn(
+                req.guacamole.url,
+                token,
+                ds,
+                name=vm_name + "-rdp",
+                proto="rdp",
+                params={"hostname": "hypervisor", "port": "33389", "security": "nla"},
+                parent=req.guacamole.folder_id,
+            )
+
+        guac_create_conn(
+            req.guacamole.url,
+            token,
+            ds,
+            name=vm_name + "-vnc",
+            proto="vnc",
+            params={"hostname": "hypervisor", "port": str(vnc_port)},
+            parent=req.guacamole.folder_id,
+        )
+    except Exception as e:
+        return {"vm": vm_name, "mac": mac, "vnc_port": vnc_port, "guac_warning": str(e)}
+
+    return {"vm": vm_name, "mac": mac, "vnc_port": vnc_port, "guac_connections": "created"}
 
 @app.get("/api/vms/{vm_id}", response_model=OverviewData)
 def get_vm_info(vm_id: str):

--- a/src/main.py
+++ b/src/main.py
@@ -12,11 +12,14 @@ import re
 import libvirt
 import guestfs
 import requests
-from virtinst import Guest
-from virtinst.device.disk import DeviceDisk
-from virtinst.device.interface import DeviceInterface
-from virtinst.device.cloudinit import DeviceCloudInit
-from virtinst.device.graphics import DeviceGraphics
+import subprocess
+import tempfile
+import shutil
+# from virtinst import Guest                     # (old)
+# from virtinst.device.disk import DeviceDisk    # (old)
+# from virtinst.device.interface import DeviceInterface  # (old)
+# from virtinst.device.cloudinit import DeviceCloudInit  # (old)
+# from virtinst.device.graphics import DeviceGraphics    # (old)
 from contextlib import asynccontextmanager
 
 # ---------------- Libvirt Connection ----------------
@@ -286,6 +289,7 @@ def _wait_for_state(dom, target_code: int, timeout: int = 30) -> bool:
 # ----- VM Creation Helpers -----
 POOL_DIR = "/var/lib/libvirt/images"
 VIRTIO_ISO = "/usr/share/virtio-win/virtio-win.iso"
+QEMU_IMG = "qemu-img"
 
 def detect_os(img_path: str) -> str:
     g = guestfs.GuestFS(python_return_dict=True)
@@ -340,82 +344,125 @@ def list_vm_images():
 
 @app.post("/api/vms/create")
 def create_vm(req: VMRequest):
-    vm_name = req.vm_name or f"vm-{uuid.uuid4().hex[:8]}"
-    mac = gen_mac(vm_name)
-
+    vm = req.vm_name or f"vm-{uuid.uuid4().hex[:8]}"
+    mac = gen_mac(vm)
     guest_os = detect_os(req.base_image)
-    conn = _require_conn()
-    g = Guest(conn)
-    g.name, g.memory, g.vcpus = vm_name, req.memory, req.vcpus
-    g.os_type = "hvm"
-    g.os_variant = "ubuntu24.04" if guest_os == "linux" else "win10"
 
-    overlay = f"{POOL_DIR}/{vm_name}.qcow2"
-    d = DeviceDisk(g)
-    d.source_file = overlay
-    d.backing_store = req.base_image
-    d.driver_type = "qcow2"
-    d.size = req.disk_gb
-    d.bus, d.create = "virtio", True
-    g.devices.append(d)
+    # 1. 创建差分盘
+    overlay = f"{POOL_DIR}/{vm}.qcow2"
+    subprocess.run([
+        QEMU_IMG,
+        "create",
+        "-f",
+        "qcow2",
+        "-F",
+        "qcow2",
+        "-o",
+        f"backing_file={req.base_image}",
+        overlay,
+        f"{req.disk_gb}G",
+    ], check=True)
 
-    iface = DeviceInterface(g)
-    iface.type = DeviceInterface.TYPE_USER
-    iface.hostfwd = [
-        "tcp::2222-:22",
-        "tcp::33389-:3389",
-    ]
-    iface.mac_address = mac
-    g.devices.append(iface)
+    # 2. 生成 Cloud-Init 文件
+    tmpdir = tempfile.mkdtemp(prefix=f"{vm}-ci-")
+    try:
+        if guest_os == "linux":
+            udata = textwrap.dedent(
+                f"""\
+                #cloud-config
+                hostname: {vm}
+                users:
+                  - default
+                  - name: ubuntu
+                    sudo: ALL=(ALL) NOPASSWD:ALL
+                    ssh_authorized_keys:
+                      - {req.ssh_key or ''}
+                """
+            )
+        else:
+            if not req.admin_password:
+                raise HTTPException(422, "Windows VM requires admin_password")
+            udata = textwrap.dedent(
+                f"""\
+                #cloud-config
+                password: {req.admin_password}
+                username: Administrator
+                runcmd:
+                  - powershell -Command "Set-ItemProperty -Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' -Name fDenyTSConnections -Value 0"
+                  - powershell -Command "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
+                """
+            )
 
-    if guest_os == "linux":
-        user_data = textwrap.dedent(f"""\
-            #cloud-config
-            hostname: {vm_name}
-            users:
-              - default
-              - name: ubuntu
-                sudo: ALL=(ALL) NOPASSWD:ALL
-                ssh_authorized_keys:
-                  - {req.ssh_key or ''}
-        """)
-    else:
-        if not req.admin_password:
-            raise HTTPException(422, "Windows VM requires admin_password")
-        user_data = textwrap.dedent(f"""\
-            #cloud-config
-            password: {req.admin_password}
-            username: Administrator
-            runcmd:
-              - powershell -Command "Set-ItemProperty -Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' -Name fDenyTSConnections -Value 0"
-              - powershell -Command "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
-        """)
+        with open(os.path.join(tmpdir, "user-data"), "w") as f:
+            f.write(udata)
+        with open(os.path.join(tmpdir, "meta-data"), "w") as f:
+            f.write(f"instance-id: {vm}\nlocal-hostname: {vm}\n")
+        open(os.path.join(tmpdir, "network-config"), "w").close()
 
-    ci = DeviceCloudInit(g)
-    ci.user_data = user_data
-    ci.disable = True
-    g.devices.append(ci)
+        ci_param = ",".join(
+            [
+                f"user-data={os.path.join(tmpdir, 'user-data')}",
+                f"meta-data={os.path.join(tmpdir, 'meta-data')}",
+                "network-config=" + os.path.join(tmpdir, "network-config"),
+                "disable=on",
+            ]
+        )
 
-    if guest_os == "windows":
-        drv = DeviceDisk(g)
-        drv.device = DeviceDisk.DEVICE_CDROM
-        drv.read_only = True
-        drv.source_file = VIRTIO_ISO
-        drv.bus = "sata"
-        g.devices.append(drv)
+        disk_root = (
+            f"path={overlay},format=qcow2,bus=virtio,backing_file={req.base_image}"
+        )
 
-    vnc = DeviceGraphics(g)
-    vnc.type, vnc.port, vnc.listen = "vnc", -1, "0.0.0.0"
-    g.devices.append(vnc)
+        network_arg = (
+            "user,model=virtio,mac="
+            f"{mac},hostfwd=tcp::2222-:22,hostfwd=tcp::33389-:3389"
+        )
 
-    dom_xml = g.get_xml_config()
-    dom = conn.defineXML(dom_xml)
-    dom.create()
+        cmd = [
+            "virt-install",
+            "--import",
+            "--quiet",
+            "--name",
+            vm,
+            "--memory",
+            str(req.memory),
+            "--vcpus",
+            str(req.vcpus),
+            "--os-variant",
+            "ubuntu24.04" if guest_os == "linux" else "win10",
+            "--graphics",
+            "vnc,listen=0.0.0.0",
+            "--noautoconsole",
+            "--wait",
+            "0",
+            "--disk",
+            disk_root,
+            "--network",
+            network_arg,
+            "--cloud-init",
+            ci_param,
+        ]
+
+        if guest_os == "windows":
+            cmd += [
+                "--disk",
+                f"path={VIRTIO_ISO},device=cdrom,readonly=on,bus=sata",
+            ]
+
+        subprocess.run(cmd, check=True)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    # 3. 查询 VNC 端口
+    lv = libvirt.open("qemu:///system")
+    dom = lv.lookupByName(vm)
     vnc_port = parse_vnc_port(dom.XMLDesc()) or 5900
 
+    # 4. Guacamole 集成
     try:
         token, ds = guac_login(
-            req.guacamole.url, req.guacamole.username, req.guacamole.password
+            req.guacamole.url,
+            req.guacamole.username,
+            req.guacamole.password,
         )
 
         if guest_os == "linux":
@@ -423,7 +470,7 @@ def create_vm(req: VMRequest):
                 req.guacamole.url,
                 token,
                 ds,
-                name=vm_name + "-ssh",
+                name=vm + "-ssh",
                 proto="ssh",
                 params={"hostname": "hypervisor", "port": "2222", "username": "ubuntu"},
                 parent=req.guacamole.folder_id,
@@ -433,7 +480,7 @@ def create_vm(req: VMRequest):
                 req.guacamole.url,
                 token,
                 ds,
-                name=vm_name + "-rdp",
+                name=vm + "-rdp",
                 proto="rdp",
                 params={"hostname": "hypervisor", "port": "33389", "security": "nla"},
                 parent=req.guacamole.folder_id,
@@ -443,15 +490,15 @@ def create_vm(req: VMRequest):
             req.guacamole.url,
             token,
             ds,
-            name=vm_name + "-vnc",
+            name=vm + "-vnc",
             proto="vnc",
             params={"hostname": "hypervisor", "port": str(vnc_port)},
             parent=req.guacamole.folder_id,
         )
     except Exception as e:
-        return {"vm": vm_name, "mac": mac, "vnc_port": vnc_port, "guac_warning": str(e)}
+        return {"vm": vm, "mac": mac, "vnc_port": vnc_port, "guac_warning": str(e)}
 
-    return {"vm": vm_name, "mac": mac, "vnc_port": vnc_port, "guac_connections": "created"}
+    return {"vm": vm, "mac": mac, "vnc_port": vnc_port, "guac_connections": "created"}
 
 @app.get("/api/vms/{vm_id}", response_model=OverviewData)
 def get_vm_info(vm_id: str):

--- a/src/main.py
+++ b/src/main.py
@@ -333,6 +333,18 @@ def guac_create_conn(url: str, token: str, ds: str, name: str, proto: str, param
         )
     return conn_id
 
+def guac_find_conn(url: str, token: str, ds: str, name: str) -> str | None:
+    r = requests.get(
+        f"{url}/api/session/data/{ds}/connections",
+        params={"token": token},
+    )
+    if not r.ok:
+        return None
+    for cid, info in r.json().items():
+        if info.get("name") == name:
+            return cid
+    return None
+
 # ---------------- API Endpoints ----------------
 @app.get("/api/vms", response_model=List[VmInstance])
 def list_vms():
@@ -499,6 +511,17 @@ def create_vm(req: VMRequest):
         return {"vm": vm, "mac": mac, "vnc_port": vnc_port, "guac_warning": str(e)}
 
     return {"vm": vm, "mac": mac, "vnc_port": vnc_port, "guac_connections": "created"}
+
+
+@app.get("/api/vms/{vm_name}/guac")
+def get_guac_info(vm_name: str, url: str, username: str, password: str):
+    token, ds = guac_login(url, username, password)
+    conns = {}
+    for proto in ["ssh", "rdp", "vnc"]:
+        cid = guac_find_conn(url, token, ds, f"{vm_name}-{proto}")
+        if cid:
+            conns[proto] = cid
+    return {"token": token, "ds": ds, "connections": conns}
 
 @app.get("/api/vms/{vm_id}", response_model=OverviewData)
 def get_vm_info(vm_id: str):

--- a/src/main.py
+++ b/src/main.py
@@ -581,15 +581,19 @@ def list_vm_snapshots(vm_id: str):
     conn = _require_conn()
     dom = conn.lookupByUUIDString(vm_id)
     snaps = []
+    import xml.etree.ElementTree as ET
     for name in dom.snapshotListNames(0):
         snap = dom.snapshotLookupByName(name, 0)
-        info = snap.getInfo()
+        xml = snap.getXMLDesc()
+        tree = ET.fromstring(xml)
+        ctime = tree.findtext("creationTime")
+        created = datetime.fromtimestamp(int(ctime)) if ctime else datetime.now()
         snaps.append(
             Snapshot(
                 id=name,
                 name=name,
-                created=datetime.fromtimestamp(info[1]),
-                xml=snap.getXMLDesc(),
+                created=created,
+                xml=xml,
             )
         )
     return snaps
@@ -599,10 +603,20 @@ def create_vm_snapshot(vm_id: str, snapshot_data: SnapshotCreate):
     conn = _require_conn()
     dom = conn.lookupByUUIDString(vm_id)
     snap_xml = f"<domainsnapshot><name>{snapshot_data.name}</name><description>{snapshot_data.description or ''}</description></domainsnapshot>"
+    import xml.etree.ElementTree as ET
     try:
         snap = dom.snapshotCreateXML(snap_xml, 0)
-        info = snap.getInfo()
-        return Snapshot(id=snap.getName(), name=snap.getName(), description=snapshot_data.description, created=datetime.fromtimestamp(info[1]), xml=snap.getXMLDesc())
+        xml = snap.getXMLDesc()
+        tree = ET.fromstring(xml)
+        ctime = tree.findtext("creationTime")
+        created = datetime.fromtimestamp(int(ctime)) if ctime else datetime.now()
+        return Snapshot(
+            id=snap.getName(),
+            name=snap.getName(),
+            description=snapshot_data.description,
+            created=created,
+            xml=xml,
+        )
     except libvirt.libvirtError as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/src/package.json
+++ b/src/package.json
@@ -34,7 +34,8 @@
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
     "swr": "^2.3.4",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "guacamole-common-js": "^1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- add endpoint `/api/vms/create` to create VMs and auto-register Guacamole connections
- provide `CreateVmModal` component for VM instance creation
- update VM image management page with start buttons and launch modal
- add create instance button to VM instances page

## Testing
- `python3 -m py_compile src/main.py`
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868e16400108320bfc8787ae1efa8a3