### PR TITLE
Switch to guacamole-lite

### DIFF
--- a/back/app/Http/Controllers/Vm/MainCli/VmController.php
+++ b/back/app/Http/Controllers/Vm/MainCli/VmController.php
@@ -66,10 +66,6 @@ class VmController extends Controller
             'ssh_key' => '--ssh-key',
             'admin_password' => '--admin-password',
             'static_ip' => '--static-ip',
-            'guac_url' => '--guac-url',
-            'guac_username' => '--guac-username',
-            'guac_password' => '--guac-password',
-            'guac_folder_id' => '--guac-folder-id',
         ] as $key => $flag) {
             if (isset($data[$key]) && $data[$key] !== null) {
                 $args[] = $flag;
@@ -82,19 +78,7 @@ class VmController extends Controller
     // GET /vms/{vm_name}/guac
     public function getGuacInfo($vmName, Request $request)
     {
-        $query = $request->query();
-        $args = ['guac-info', $vmName];
-        foreach ([
-            'url' => '--url',
-            'username' => '--username',
-            'password' => '--password',
-        ] as $key => $flag) {
-            if (isset($query[$key])) {
-                $args[] = $flag;
-                $args[] = (string) $query[$key];
-            }
-        }
-        return $this->runCli($args);
+        return $this->runCli(['guac-info', $vmName]);
     }
 
     // GET /vms/{vm_id}

--- a/src/GUACAMOLE_SETUP.md
+++ b/src/GUACAMOLE_SETUP.md
@@ -1,8 +1,10 @@
 # guacd + guacamole-lite 使用说明
 
-本项目现使用 `guacd` 搭配 Node.js 包 [`guacamole-lite`](https://github.com/netbrain/guacamole-lite) 提供远程桌面代理，不再依赖完整的 Apache Guacamole Web 服务。
+本项目通过 `guacd` 搭配 Node.js 包 [`guacamole-lite`](https://github.com/netbrain/guacamole-lite) 提供远程桌面代理，已不再依赖完整的 Apache Guacamole Web 服务。但浏览器与服务器之间仍需 `guacd` 作为后端支撑。
 
-## 1. 启动 guacd
+## 1. 安装并运行 guacd
+
+推荐使用 Docker 快速部署：
 
 ```bash
 sudo apt update
@@ -10,15 +12,31 @@ sudo apt install -y docker.io
 sudo docker run -d --name guacd -p 4822:4822 guacamole/guacd:1.5.4
 ```
 
+或在 Debian/Ubuntu 直接安装系统包：
+
+```bash
+sudo apt install -y guacamole-server
+sudo systemctl enable --now guacd
+```
+
 如需使用其他端口，可在启动 `server.js` 时设置环境变量 `GUACD_PORT`。
 
-## 2. Node.js 集成
+## 2. 后端集成原理
 
-`src/server.js` 会在 `/api/guac` 路径下创建 `guacamole-lite` 实例并连接到 `guacd`。
-前端通过如下 URL 即可建立会话：
+启动 Node.js 服务器时，`src/server.js` 会在 `/api/guac` 路径下创建 `GuacamoleLite` 实例并连接到本地 `guacd`。浏览器与该路径建立 WebSocket 后，由 `guacamole-lite` 根据连接参数转发到 `guacd`。
+
+`src/main_cli_local.py` 的 `guac-info` 命令返回虚拟机的主机名以及三种远程桌面端口，PHP 控制器 `/api/php/vms/<name>/guac` 调用此命令并将结果交给前端。
+
+## 3. 前端调用方式
+
+前端收到连接信息后，根据协议构造如下地址打开新窗口：
 
 ```
 /guac?type=<protocol>&hostname=<host>&port=<port>
 ```
 
-其中 `<protocol>` 为 `ssh`、`rdp` 或 `vnc`。完成以上步骤后，虚拟机管理界面点击对应按钮即可在浏览器中打开远程桌面。
+- `protocol`：`ssh`、`rdp` 或 `vnc`
+- `hostname`：远程主机地址（通常为 `hypervisor`）
+- `port`：对应协议端口号
+
+`src/app/guac/page.tsx` 会解析这些参数并通过 `guacamole-common-js` 连接到 `/api/guac`，无需额外的 Guacamole 凭据即可显示远程桌面。

--- a/src/GUACAMOLE_SETUP.md
+++ b/src/GUACAMOLE_SETUP.md
@@ -1,110 +1,24 @@
-# Guacamole 安装与配置指南
+# guacd + guacamole-lite 使用说明
 
-本文档描述如何在本服务器上部署 [Apache Guacamole](https://guacamole.apache.org/) 并使 `src/main_cli.py` 中的 `/api/vms/create` 接口能够自动创建 SSH、VNC 与 RDP 连接。
+本项目现使用 `guacd` 搭配 Node.js 包 [`guacamole-lite`](https://github.com/netbrain/guacamole-lite) 提供远程桌面代理，不再依赖完整的 Apache Guacamole Web 服务。
 
-## 1. Docker 安装
-
-推荐使用 Docker 快速部署 Guacamole，无需手动编译 `guacd` 与 Web 应用。
-以下示例使用 `docker-compose` 在同一台服务器上同时运行 `guacd` 与
-`guacamole` Web 容器：
+## 1. 启动 guacd
 
 ```bash
 sudo apt update
-sudo apt install -y docker.io docker-compose
+sudo apt install -y docker.io
+sudo docker run -d --name guacd -p 4822:4822 guacamole/guacd:1.5.4
 ```
 
-创建 `docker-compose.yml`：
+如需使用其他端口，可在启动 `server.js` 时设置环境变量 `GUACD_PORT`。
 
-```yaml
-version: '3'
-services:
-  guacd:
-    image: guacamole/guacd:1.5.4
-    container_name: guacd
-    restart: unless-stopped
-  guacamole:
-    image: guacamole/guacamole:1.5.4
-    container_name: guacamole
-    restart: unless-stopped
-    environment:
-      GUACD_HOSTNAME: guacd
-    ports:
-      - "8080:8080"
-    depends_on:
-      - guacd
-```
+## 2. Node.js 集成
 
-启动服务：
-
-```bash
-sudo docker-compose up -d
-```
-
-容器就绪后，可在浏览器访问 `http://<服务器IP>:8080/guacamole` 进入 Web 界面。
-
-## 2. 部署 Web 应用
-
-下载 Guacamole Web 应用并放入 Tomcat 的 `webapps` 目录：
-
-```bash
-wget https://downloads.apache.org/guacamole/1.5.4/binary/guacamole-1.5.4.war \
-  -O /var/lib/tomcat9/webapps/guacamole.war
-sudo systemctl restart tomcat9
-```
-
-创建配置目录 `/etc/guacamole` 并添加 `guacamole.properties`：
-
-```bash
-sudo mkdir -p /etc/guacamole
-cat <<'_EOF' | sudo tee /etc/guacamole/guacamole.properties
-# guacd 连接信息
- guacd-hostname: localhost
- guacd-port: 4822
-_EOF
-```
-
-将该目录链接到 Tomcat：
-
-```bash
-sudo ln -s /etc/guacamole /var/lib/tomcat9/.guacamole
-```
-
-## 3. 创建登录账户
-
-为了让后端调用 REST API，需要在 `user-mapping.xml` 中定义至少一个用户：
-
-```bash
-cat <<'_EOF' | sudo tee /etc/guacamole/user-mapping.xml
-<user-mapping>
-    <authorize username="guacadmin" password="guacpass">
-        <connection name="placeholder" protocol="vnc" />
-    </authorize>
-</user-mapping>
-_EOF
-sudo systemctl restart tomcat9
-```
-
-登录地址为 `http://<服务器IP>:8080/guacamole`，使用上述用户名和密码即可登录。
-
-## 4. 确保名称解析
-
-`/api/vms/create` 会在 Guacamole 中生成指向主机名 `hypervisor` 的连接，请确保在运行 Guacamole 的服务器上能解析此主机名，例如在 `/etc/hosts` 中加入：
+`src/server.js` 会在 `/api/guac` 路径下创建 `guacamole-lite` 实例并连接到 `guacd`。
+前端通过如下 URL 即可建立会话：
 
 ```
-127.0.0.1   hypervisor
+/guac?type=<protocol>&hostname=<host>&port=<port>
 ```
 
-或将其指向实际的虚拟化宿主机 IP。
-
-## 5. 测试 REST API
-
-部署完成后，可使用以下命令测试登录及创建连接是否正常：
-
-```bash
-curl -X POST "http://<服务器IP>:8080/guacamole/api/tokens" \
-     -d "username=guacadmin" -d "password=guacpass"
-```
-
-返回 JSON 中应包含 `authToken`。随后即可按照 `src/main_cli.py` 中的逻辑创建 SSH、VNC、RDP 连接。
-
-完成以上步骤后，前端在调用 `/api/vms/create` 时填写相同的 Guacamole URL 与凭据，即可在 Guacamole 中自动生成对应连接。
+其中 `<protocol>` 为 `ssh`、`rdp` 或 `vnc`。完成以上步骤后，虚拟机管理界面点击对应按钮即可在浏览器中打开远程桌面。

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -5,27 +5,28 @@ import * as Guacamole from 'guacamole-common-js'
 
 export default function GuacPage() {
   const params = useSearchParams();
-  const url = params.get('url') || '';
-  const token = params.get('token') || '';
-  const ds = params.get('ds') || '';
-  const id = params.get('id') || '';
+  const type = params.get('type') || '';
+  const hostname = params.get('hostname') || '';
+  const port = params.get('port') || '';
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!ref.current || !url || !token || !id || !ds) return;
-    const ws = url.replace(/^http/, 'ws') + '/websocket-tunnel?token=' + token;
+    if (!ref.current || !type || !hostname || !port) return;
+    const wsBase = window.location.origin.replace(/^http/, 'ws');
+    const ws = wsBase + '/api/guac?' +
+      new URLSearchParams({ type, hostname, port }).toString();
     const tunnel = new Guacamole.WebSocketTunnel(ws);
     const client = new Guacamole.Client(tunnel);
     ref.current.innerHTML = '';
     ref.current.appendChild(client.getDisplay().getElement());
-    client.connect(`token=${token}&connection=${id}&GUAC_DATA_SOURCE=${ds}`);
+    client.connect();
     const disconnect = () => client.disconnect();
     window.addEventListener('beforeunload', disconnect);
     return () => {
       window.removeEventListener('beforeunload', disconnect);
       client.disconnect();
     };
-  }, [url, token, ds, id]);
+  }, [type, hostname, port]);
 
   return <div ref={ref} style={{width:'100vw',height:'100vh',background:'#000'}}/>;
 }

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -192,31 +192,15 @@ export default function VmPage() {
         }
     };
 
-    const getGuacCreds = async () => {
-        let url = localStorage.getItem('guac_url') || '';
-        let user = localStorage.getItem('guac_user') || '';
-        let pass = localStorage.getItem('guac_pass') || '';
-        if (!url) url = prompt('Guacamole URL', 'http://localhost:8080/guacamole') || '';
-        if (!user) user = prompt('Guacamole Username', '') || '';
-        if (!pass) pass = prompt('Guacamole Password', '') || '';
-        localStorage.setItem('guac_url', url);
-        localStorage.setItem('guac_user', user);
-        localStorage.setItem('guac_pass', pass);
-        return { url, user, pass };
-    };
-
     const handleGuac = async (proto: 'ssh' | 'rdp' | 'vnc') => {
         if (!current) return;
-        const { url, user, pass } = await getGuacCreds();
         try {
-            const q = new URLSearchParams({ url, username: user, password: pass }).toString();
-            const res = await fetch(`/api/php/vms/${current.name}/guac?${q}`);
-            if (!res.ok) throw new Error('Guacamole request failed');
-            const data = await res.json();
-            const id = data.connections?.[proto];
-            if (!id) throw new Error('Connection not found');
-            const dest = `/guac?url=${encodeURIComponent(url)}&token=${encodeURIComponent(data.token)}&ds=${encodeURIComponent(data.ds)}&id=${encodeURIComponent(id)}`;
-            window.open(dest, '_blank');
+            const res = await fetch(`/api/php/vms/${current.name}/guac`);
+            if (!res.ok) throw new Error('Guacamole info request failed');
+            const info = await res.json();
+            const port = proto === 'ssh' ? info.ssh_port : proto === 'rdp' ? info.rdp_port : info.vnc_port;
+            const q = new URLSearchParams({ type: proto, hostname: info.host, port: String(port) }).toString();
+            window.open(`/guac?${q}`, '_blank');
         } catch (e: any) {
             alert(e.message || 'Failed to open connection');
         }

--- a/src/main_cli_local.py
+++ b/src/main_cli_local.py
@@ -10,7 +10,6 @@ import time
 import textwrap
 import json
 import re
-import requests
 import subprocess
 import tempfile
 import shutil
@@ -149,12 +148,6 @@ class EventLog(BaseModel):
     details: Optional[Dict[str, Any]] = None
 
 # ----- VM Creation Models -----
-class GuacInfo(BaseModel):
-    url: str
-    username: str
-    password: str
-    folder_id: Optional[str] = "ROOT"
-
 class VMRequest(BaseModel):
     vm_name: Optional[str] = None
     base_image: str
@@ -164,7 +157,6 @@ class VMRequest(BaseModel):
     ssh_key: Optional[str] = None
     admin_password: Optional[str] = None
     static_ip: Optional[str] = None
-    guacamole: GuacInfo
 
 # ---------------- Helper Functions ----------------
 def _require_conn():
@@ -372,42 +364,6 @@ def parse_vnc_port(xml: str) -> int | None:
     m = re.search(r"<graphics[^>]*type='vnc'[^>]*port='(\d+)'", xml)
     return int(m.group(1)) if m else None
 
-def guac_login(url: str, username: str, password: str) -> tuple[str, str]:
-    r = requests.post(f"{url}/api/tokens", data={"username": username, "password": password})
-    if not r.ok:
-        raise RuntimeError("Guacamole auth failed")
-    data = r.json()
-    return data["authToken"], next(iter(data["dataSource"]))
-
-def guac_create_conn(url: str, token: str, ds: str, name: str, proto: str, params: dict, parent: str | None):
-    body = {
-        "name": name,
-        "protocol": proto,
-        "parameters": params,
-        "attributes": {"max-connections": "5", "max-connections-per-user": "2"},
-    }
-    r = requests.post(f"{url}/api/session/data/{ds}/connections", params={"token": token}, json=body)
-    if not r.ok:
-        raise RuntimeError("create connection failed")
-    conn_id = r.json()
-    if parent and parent != "ROOT":
-        requests.post(
-            f"{url}/api/session/data/{ds}/connectionGroups/{parent}/connections/{conn_id}",
-            params={"token": token},
-        )
-    return conn_id
-
-def guac_find_conn(url: str, token: str, ds: str, name: str) -> str | None:
-    r = requests.get(
-        f"{url}/api/session/data/{ds}/connections",
-        params={"token": token},
-    )
-    if not r.ok:
-        return None
-    for cid, info in r.json().items():
-        if info.get("name") == name:
-            return cid
-    return None
 
 # ---------------- CLI Functions ----------------
 def list_vms():
@@ -532,58 +488,22 @@ def create_vm(req: VMRequest):
     except RuntimeError:
         vnc_port = 5900
 
-    # 4. Guacamole 集成
+    return {"vm": vm, "mac": mac, "vnc_port": vnc_port}
+
+
+def get_guac_info(vm_name: str):
     try:
-        token, ds = guac_login(
-            req.guacamole.url,
-            req.guacamole.username,
-            req.guacamole.password,
-        )
+        xml = run_virsh("dumpxml", vm_name)
+        vnc_port = parse_vnc_port(xml) or 5900
+    except RuntimeError:
+        vnc_port = 5900
 
-        if guest_os == "linux":
-            guac_create_conn(
-                req.guacamole.url,
-                token,
-                ds,
-                name=vm + "-ssh",
-                proto="ssh",
-                params={"hostname": "hypervisor", "port": "2222", "username": "ubuntu"},
-                parent=req.guacamole.folder_id,
-            )
-        else:
-            guac_create_conn(
-                req.guacamole.url,
-                token,
-                ds,
-                name=vm + "-rdp",
-                proto="rdp",
-                params={"hostname": "hypervisor", "port": "33389", "security": "nla"},
-                parent=req.guacamole.folder_id,
-            )
-
-        guac_create_conn(
-            req.guacamole.url,
-            token,
-            ds,
-            name=vm + "-vnc",
-            proto="vnc",
-            params={"hostname": "hypervisor", "port": str(vnc_port)},
-            parent=req.guacamole.folder_id,
-        )
-    except Exception as e:
-        return {"vm": vm, "mac": mac, "vnc_port": vnc_port, "guac_warning": str(e)}
-
-    return {"vm": vm, "mac": mac, "vnc_port": vnc_port, "guac_connections": "created"}
-
-
-def get_guac_info(vm_name: str, url: str, username: str, password: str):
-    token, ds = guac_login(url, username, password)
-    conns = {}
-    for proto in ["ssh", "rdp", "vnc"]:
-        cid = guac_find_conn(url, token, ds, f"{vm_name}-{proto}")
-        if cid:
-            conns[proto] = cid
-    return {"token": token, "ds": ds, "connections": conns}
+    return {
+        "host": "hypervisor",
+        "ssh_port": 2222,
+        "rdp_port": 33389,
+        "vnc_port": vnc_port,
+    }
 
 def get_vm_info(vm_id: str):
     try:
@@ -866,10 +786,7 @@ def main():
     p_create.add_argument("--ssh-key")
     p_create.add_argument("--admin-password")
     p_create.add_argument("--static-ip")
-    p_create.add_argument("--guac-url", required=True)
-    p_create.add_argument("--guac-username", required=True)
-    p_create.add_argument("--guac-password", required=True)
-    p_create.add_argument("--guac-folder-id", default="ROOT")
+    # Guacamole parameters removed in lite mode
 
     def _create_vm(args):
         req = VMRequest(
@@ -881,12 +798,6 @@ def main():
             ssh_key=args.ssh_key,
             admin_password=args.admin_password,
             static_ip=args.static_ip,
-            guacamole=GuacInfo(
-                url=args.guac_url,
-                username=args.guac_username,
-                password=args.guac_password,
-                folder_id=args.guac_folder_id,
-            ),
         )
         return create_vm(req)
 
@@ -894,10 +805,7 @@ def main():
 
     p_guac = sub.add_parser("guac-info")
     p_guac.add_argument("vm_name")
-    p_guac.add_argument("--url", required=True)
-    p_guac.add_argument("--username", required=True)
-    p_guac.add_argument("--password", required=True)
-    p_guac.set_defaults(func=lambda a: get_guac_info(a.vm_name, a.url, a.username, a.password))
+    p_guac.set_defaults(func=lambda a: get_guac_info(a.vm_name))
 
     p_get = sub.add_parser("get-vm")
     p_get.add_argument("vm_id")

--- a/src/package.json
+++ b/src/package.json
@@ -35,7 +35,8 @@
     "socket.io-client": "^4.7.5",
     "swr": "^2.3.4",
     "uuid": "^11.1.0",
-    "guacamole-common-js": "^1.5.0"
+    "guacamole-common-js": "^1.5.0",
+    "guacamole-lite": "^1.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@
 import { createServer } from 'http';
 import next from 'next';
 import { Server } from 'socket.io';
+import GuacamoleLite from 'guacamole-lite';
 import { spawn as ptySpawn } from '@homebridge/node-pty-prebuilt-multiarch';
 import { spawn as childProcessSpawn } from 'child_process';
 import { createProxyMiddleware } from 'http-proxy-middleware';
@@ -24,6 +25,7 @@ const PHP_API_HOST = process.env.PHP_API_HOST || '127.0.0.1';
 const PHP_TARGET_URL = `http://${PHP_API_HOST}:${PHP_API_PORT}`;
 
 let httpServer;
+let guacServer;
 //let fastApiProcess = null; // will hold FastAPI child process
 
 // Track all open TCP sockets so we can destroy them on shutdown
@@ -117,6 +119,20 @@ app.prepare().then(() => {
     return handle(req, res);
   });
 
+  // guacamole-lite server
+  guacServer = new GuacamoleLite(
+    { server: httpServer, path: '/api/guac' },
+    { port: parseInt(process.env.GUACD_PORT || '4822', 10) },
+    {
+      allowedUnencryptedConnectionSettings: {
+        rdp: ['hostname', 'port', 'username', 'password', 'security', 'ignore-cert'],
+        ssh: ['hostname', 'port', 'username', 'password'],
+        vnc: ['hostname', 'port', 'password'],
+        join: ['id']
+      }
+    }
+  );
+
   // 记录所有 TCP 连接
   httpServer.on('connection', (socket) => {
     sockets.add(socket);
@@ -161,6 +177,10 @@ app.prepare().then(() => {
 
     // 2) 关闭 socket.io (会关闭所有 namespace / room)
     await new Promise((resolve) => io.close(resolve));
+
+    if (guacServer) {
+      guacServer.close();
+    }
 
     // 3) 关闭 HTTP 服务器（停止接收新连接）
     await new Promise((resolve) => httpServer.close(resolve));


### PR DESCRIPTION
## Summary
- remove guacamole credentials from PHP controller
- simplify VM CLI to drop guacamole API calls
- update VM UI page to open guacamole-lite sessions
- adapt Guac page for new connection params
- integrate guacamole-lite server in Node server
- add guacamole-lite dependency

## Testing
- `python3 -m py_compile src/main_cli_local.py`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686a1d301d9883208256af1d16465fa8