### PR TITLE
Fix VNC Guacamole token handling

### DIFF
--- a/src/app/api/guac-token/route.ts
+++ b/src/app/api/guac-token/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+
+const CIPHER = 'AES-256-CBC';
+const KEY = process.env.GUAC_KEY || '0123456789abcdef0123456789abcdef';
+
+function encryptToken(value: any) {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(CIPHER, Buffer.from(KEY), iv);
+  let encrypted = cipher.update(JSON.stringify(value), 'utf8', 'base64');
+  encrypted += cipher.final('base64');
+  const data = { iv: iv.toString('base64'), value: encrypted };
+  const json = JSON.stringify(data);
+  return Buffer.from(json).toString('base64');
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get('type');
+  const hostname = searchParams.get('hostname');
+  const port = searchParams.get('port');
+  if (!type || !hostname || !port) {
+    return NextResponse.json({ error: 'Missing params' }, { status: 400 });
+  }
+  const tokenObj = {
+    connection: { type, settings: { hostname, port } }
+  };
+  const token = encryptToken(tokenObj);
+  return NextResponse.json({ token });
+}

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -1,9 +1,11 @@
 'use client'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, Suspense } from 'react'
 import Guacamole from 'guacamole-common-js'
 
-export default function GuacPage() {
+export const dynamic = 'force-dynamic'
+
+function GuacInner() {
   const params = useSearchParams();
   const type = params.get('type') || '';
   const hostname = params.get('hostname') || '';
@@ -12,21 +14,37 @@ export default function GuacPage() {
 
   useEffect(() => {
     if (!ref.current || !type || !hostname || !port) return;
-    const wsBase = window.location.origin.replace(/^http/, 'ws');
-    const ws = wsBase + '/api/guac?' +
-      new URLSearchParams({ type, hostname, port }).toString();
-    const tunnel = new Guacamole.WebSocketTunnel(ws);
-    const client = new Guacamole.Client(tunnel);
-    ref.current.innerHTML = '';
-    ref.current.appendChild(client.getDisplay().getElement());
-    client.connect();
-    const disconnect = () => client.disconnect();
+    let client: Guacamole.Client | null = null;
+    let ignore = false;
+    const params = new URLSearchParams({ type, hostname, port }).toString();
+    fetch('/api/guac-token?' + params)
+      .then(r => r.json())
+      .then(data => {
+        if (ignore || !ref.current || !data.token) return;
+        const wsBase = window.location.origin.replace(/^http/, 'ws');
+        const ws = wsBase + '/api/guac?token=' + encodeURIComponent(data.token);
+        const tunnel = new Guacamole.WebSocketTunnel(ws);
+        client = new Guacamole.Client(tunnel);
+        ref.current!.innerHTML = '';
+        ref.current!.appendChild(client.getDisplay().getElement());
+        client.connect();
+      });
+    const disconnect = () => client?.disconnect();
     window.addEventListener('beforeunload', disconnect);
     return () => {
+      ignore = true;
       window.removeEventListener('beforeunload', disconnect);
-      client.disconnect();
+      client?.disconnect();
     };
   }, [type, hostname, port]);
 
   return <div ref={ref} style={{width:'100vw',height:'100vh',background:'#000'}}/>;
+}
+
+export default function GuacPage() {
+  return (
+    <Suspense>
+      <GuacInner />
+    </Suspense>
+  );
 }

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -24,7 +24,10 @@ function GuacInner() {
         const wsBase = window.location.origin.replace(/^http/, 'ws');
         const ws = wsBase + '/api/guac?token=' + encodeURIComponent(data.token);
         const tunnel = new Guacamole.WebSocketTunnel(ws);
+        tunnel.onerror = status => console.error('Tunnel error', status);
         client = new Guacamole.Client(tunnel);
+        client.onerror = err => console.error('Client error', err);
+        client.onstatechange = state => console.log('Client state', state);
         ref.current!.innerHTML = '';
         ref.current!.appendChild(client.getDisplay().getElement());
         client.connect();

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,8 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import path from 'path';
 import process from 'process';
 
+const GUAC_KEY = process.env.GUAC_KEY || '0123456789abcdef0123456789abcdef';
+
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
@@ -124,6 +126,7 @@ app.prepare().then(() => {
     { server: httpServer, path: '/api/guac' },
     { port: parseInt(process.env.GUACD_PORT || '4822', 10) },
     {
+      crypt: { cypher: 'AES-256-CBC', key: GUAC_KEY },
       allowedUnencryptedConnectionSettings: {
         rdp: ['hostname', 'port', 'username', 'password', 'security', 'ignore-cert'],
         ssh: ['hostname', 'port', 'username', 'password'],


### PR DESCRIPTION
## Summary
- generate connection token with new API route `guac-token`
- use the token on the Guacamole page
- configure `server.js` with encryption key for guacamole-lite

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686aa98805a08320bacdfe407c23e194