### PR TITLE
Add VM deletion functionality

### DIFF
--- a/back/app/Http/Controllers/Vm/MainCli/VmController.php
+++ b/back/app/Http/Controllers/Vm/MainCli/VmController.php
@@ -155,4 +155,10 @@ class VmController extends Controller
     {
         return $this->runCli(['events', $vmId]);
     }
+
+    // DELETE /vms/{vm_id}
+    public function deleteVm($vmId)
+    {
+        return $this->runCli(['delete-vm', $vmId]);
+    }
 }

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -262,6 +262,7 @@
         Route::post('/create', [$c, 'createVm']);
         Route::get('/{vm_name}/guac', [$c, 'getGuacInfo']);
         Route::get('/{vm_id}', [$c, 'getVmInfo']);
+        Route::delete('/{vm_id}', [$c, 'deleteVm']);
         Route::post('/{vm_id}/actions/{action}', [$c, 'manageVmLifecycle']);
         Route::get('/{vm_id}/snapshots', [$c, 'listVmSnapshots']);
         Route::post('/{vm_id}/snapshots', [$c, 'createVmSnapshot']);

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -218,6 +218,25 @@ export default function VmPage() {
         setActionAnchor(null);
     };
 
+    const handleDelete = async () => {
+        if (!current) return;
+        if (!window.confirm(`确定删除虚拟机 ${current.name}？`)) return;
+        setActionLoading(true);
+        try {
+            const res = await fetch(`/back/api/vms/${current.id}`, { method: 'DELETE' });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.detail || res.statusText);
+            }
+            await mutate();
+            setCurrent(null);
+        } catch (e: any) {
+            alert(e.message || 'Failed to delete');
+        } finally {
+            setActionLoading(false);
+        }
+    };
+
     return (
         <Box sx={{ p: { xs: 2, sm: 3 } }}>
             {/* ---------- 顶栏 ---------- */}
@@ -384,6 +403,15 @@ export default function VmPage() {
                             startIcon={<ConsoleIcon />}
                         >
                             控制台
+                        </Button>
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            color="error"
+                            disabled={actionLoading}
+                            onClick={handleDelete}
+                        >
+                            删除
                         </Button>
                         <Button
                             size="small"

--- a/src/main_cli_local.py
+++ b/src/main_cli_local.py
@@ -633,6 +633,17 @@ def manage_vm_lifecycle(vm_id: str, action: str):
     _wait_for_state(vm_id, target_state)
     return LifecycleActionResponse(message="ok", vm_id=vm_id, action=action, state=target_state)
 
+def delete_vm(vm_id: str):
+    try:
+        try:
+            run_virsh("destroy", vm_id)
+        except RuntimeError:
+            pass
+        run_virsh("undefine", vm_id, "--remove-all-storage")
+    except RuntimeError as e:
+        raise HTTPException(500, str(e))
+    return {"message": "deleted"}
+
 def list_vm_snapshots(vm_id: str):
     snaps: List[Snapshot] = []
     try:
@@ -857,6 +868,10 @@ def main():
     p_get = sub.add_parser("get-vm")
     p_get.add_argument("vm_id")
     p_get.set_defaults(func=lambda a: get_vm_info(a.vm_id))
+
+    p_delete = sub.add_parser("delete-vm")
+    p_delete.add_argument("vm_id")
+    p_delete.set_defaults(func=lambda a: delete_vm(a.vm_id))
 
     p_lifecycle = sub.add_parser("lifecycle")
     p_lifecycle.add_argument("vm_id")


### PR DESCRIPTION
## Summary
- add a delete VM command in CLI
- expose delete route in backend controller and routes
- allow deleting VM from frontend instance page

## Testing
- `python3 -m py_compile src/main_cli_local.py`
- `npm --prefix src run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3b0151308320965627ce0309d05b