### PR TITLE
Add method param to guac API

### DIFF
--- a/back/app/Http/Controllers/Vm/MainCli/VmController.php
+++ b/back/app/Http/Controllers/Vm/MainCli/VmController.php
@@ -103,7 +103,8 @@ class VmController extends Controller
     // GET /vms/{vm_name}/guac
     public function getGuacInfo($vmName, Request $request)
     {
-        return $this->runCli(['guac-info', $vmName]);
+        $method = $request->query('method', 'ssh');
+        return $this->runCli(['guac-info', $vmName, '--method', $method]);
     }
 
     // GET /vms/{vm_id}

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -29,7 +29,6 @@ import {
     Pause as PauseIcon,
     RestartAlt as ResetIcon,
     PowerSettingsNew as ForceOffIcon,
-    Visibility as ConsoleIcon,
     DesktopWindows as VncIcon,
     Terminal as SshIcon,
     LaptopWindows as RdpIcon,
@@ -201,7 +200,7 @@ export default function VmPage() {
     const handleGuac = async (proto: 'ssh' | 'rdp' | 'vnc') => {
         if (!current) return;
         try {
-            const res = await fetch(`/back/api/vms/${current.name}/guac`);
+            const res = await fetch(`/back/api/vms/${current.name}/guac?method=${proto}`);
             if (!res.ok) throw new Error('Guacamole info request failed');
             const info = await res.json();
 
@@ -400,13 +399,6 @@ export default function VmPage() {
                             size="small"
                             variant="outlined"
                             sx={{ ml: "auto" }}
-                            startIcon={<ConsoleIcon />}
-                        >
-                            控制台
-                        </Button>
-                        <Button
-                            size="small"
-                            variant="outlined"
                             color="error"
                             disabled={actionLoading}
                             onClick={handleDelete}

--- a/src/components/vm/OverviewPanel.tsx
+++ b/src/components/vm/OverviewPanel.tsx
@@ -1,184 +1,164 @@
 "use client";
 import React from "react";
 import {
-  Alert,
-  Grid,
-  Stack,
-  Typography,
-  Paper,
-  Skeleton,
+    Alert,
+    Box,
+    Stack,
+    Typography,
+    Paper,
+    Skeleton,
 } from "@mui/material";
 import useSWR from "swr";
 
-/* ---------- 类型 ---------- */
+// --- Step 1: Import the desired icons ---
+import PowerSettingsNewOutlinedIcon from '@mui/icons-material/PowerSettingsNewOutlined';
+import TerminalOutlinedIcon from '@mui/icons-material/TerminalOutlined';
+import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
+import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
+import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
+import AutorenewOutlinedIcon from '@mui/icons-material/AutorenewOutlined';
+import DeveloperBoardOutlinedIcon from '@mui/icons-material/DeveloperBoardOutlined';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import MemoryOutlinedIcon from '@mui/icons-material/MemoryOutlined';
+import LanOutlinedIcon from '@mui/icons-material/LanOutlined';
+
+
+/* ---------- 类型 (No changes here) ---------- */
 interface OverviewPanelProps {
-  vmId: string;
+    vmId: string;
 }
+// ... (rest of the interfaces are the same)
 interface VCPUInfo {
-  count: number;
-  usage_percent: number;
+    count: number;
+    usage_percent: number;
 }
 interface VRAMInfo {
-  total_mb: number;
-  usage_mb: number;
-  usage_percent: number;
+    total_mb: number;
+    usage_mb: number;
+    usage_percent: number;
 }
 interface OverviewData {
-  status: string;
-  hostNode: string;
-  pool: string;
-  vcpu: VCPUInfo;
-  vram: VRAMInfo;
-  osType?: string;
-  persistent?: boolean;
-  autostart?: boolean;
-  uuid: string;
-  ipAddress: string;
+    status: string;
+    hostNode: string;
+    pool: string;
+    vcpu: VCPUInfo;
+    vram: VRAMInfo;
+    osType?: string;
+    persistent?: boolean;
+    autostart?: boolean;
+    uuid: string;
+    ipAddress: string;
 }
 
 
+/* --- Step 2: Update KeyValueListItem to accept icons and have larger text --- */
 const KeyValueListItem: React.FC<{
-  label: string;
-  value: string | number | undefined;
-  isLoading?: boolean;
-}> = ({ label, value, isLoading }) => (
+    label: string;
+    value: string | number | undefined;
+    isLoading?: boolean;
+    icon?: React.ReactNode; // Add icon to props
+}> = ({ label, value, isLoading, icon }) => (
     <Stack
         direction="row"
         justifyContent="space-between"
+        alignItems="center" // Vertically align items
         sx={{
-          py: 1,
-          borderBottom: "1px solid #eee",
-          "&:last-child": { borderBottom: "none" },
+            py: 1.5, // Increased padding for better spacing
+            borderBottom: "1px solid #eee",
+            "&:last-child": { borderBottom: "none" },
         }}
     >
-      <Typography variant="body2" color="text.secondary">
-        {label}:
-      </Typography>
-      {isLoading ? (
-          <Skeleton width="40%" />
-      ) : (
-          <Typography variant="body2" sx={{ textAlign: "right" }}>
-            {value ?? "N/A"}
-          </Typography>
-      )}
+        {/* Group icon and label together on the left */}
+        <Stack direction="row" alignItems="center" spacing={1.5}>
+            {isLoading ? <Skeleton variant="circular" width={22} height={22} /> : icon}
+            <Typography
+                variant="body1" /* Use body1 for larger font */
+                color="text.secondary"
+                sx={{ display: 'flex', alignItems: 'center' }}
+            >
+                {isLoading ? <Skeleton width={80} /> : `${label}:`}
+            </Typography>
+        </Stack>
+
+        {/* Value remains on the right */}
+        {isLoading ? (
+            <Skeleton width="40%" />
+        ) : (
+            <Typography variant="body1" sx={{ textAlign: "right" }}>
+                {value ?? "N/A"}
+            </Typography>
+        )}
     </Stack>
 );
 
-/* ---------- 主组件 ---------- */
+/* ---------- 主组件 (Refactored) ---------- */
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 export default function OverviewPanel({ vmId }: OverviewPanelProps) {
-  /* --- SWR 轮询，保留旧数据 --- */
-  const {
-    data,
-    error,
-    isLoading,
-  } = useSWR<OverviewData>(`/back/api/vms/${vmId}`, fetcher, {
-    refreshInterval: 5000, // 5 s 轮询
-    keepPreviousData: true,
-    refreshWhenHidden: false, // 标签页不可见时暂停
-    dedupingInterval: 5000, // 与 refreshInterval 对齐
-  });
+    const {
+        data,
+        error,
+        isLoading,
+    } = useSWR<OverviewData>(`/back/api/vms/${vmId}`, fetcher, {
+        refreshInterval: 5000,
+        keepPreviousData: true,
+        refreshWhenHidden: false,
+        dedupingInterval: 5000,
+    });
 
-  const overviewData = data ?? null;
+    const overviewData = data ?? null;
+    const initialLoading = isLoading && !data;
 
-  const initialLoading = isLoading && !data;
+    if (error) {
+        return (
+            <Alert severity="error" sx={{ m: 2 }}>
+                Error loading overview: {(error as any).message || "unknown"}
+            </Alert>
+        );
+    }
 
-  if (error) {
+    /* --- Step 3: Add the icon components to your data array --- */
+    const overviewItems = [
+        { label: "状态", value: overviewData?.status, icon: <PowerSettingsNewOutlinedIcon color="action" /> },
+        { label: "OS 类型", value: overviewData?.osType, icon: <TerminalOutlinedIcon color="action" /> },
+        { label: "宿主机", value: overviewData?.hostNode, icon: <DnsOutlinedIcon color="action" /> },
+        { label: "持久化", value: overviewData?.persistent === undefined ? undefined : overviewData.persistent ? "是" : "否", icon: <SaveOutlinedIcon color="action" /> },
+        { label: "存储池", value: overviewData?.pool, icon: <StorageOutlinedIcon color="action" /> },
+        { label: "自动启动", value: overviewData?.autostart === undefined ? undefined : overviewData.autostart ? "是" : "否", icon: <AutorenewOutlinedIcon color="action" /> },
+        { label: "vCPU 数", value: overviewData?.vcpu?.count, icon: <DeveloperBoardOutlinedIcon color="action" /> },
+        { label: "UUID", value: overviewData?.uuid, icon: <FingerprintIcon color="action" /> },
+        { label: "内存总量", value: overviewData?.vram?.total_mb !== undefined ? `${overviewData.vram.total_mb} MB` : undefined, icon: <MemoryOutlinedIcon color="action" /> },
+        { label: "IP 地址", value: overviewData?.ipAddress, icon: <LanOutlinedIcon color="action" /> },
+    ];
+
     return (
-        <Alert severity="error" sx={{ m: 2 }}>
-          Error loading overview: {(error as any).message || "unknown"}
-        </Alert>
+        <Paper variant="outlined" sx={{ p: 2 }}>
+            <Typography
+                variant="h6"
+                sx={{ mb: 1.5, borderBottom: "1px solid #ddd", pb: 1 }}
+            >
+                基本配置
+            </Typography>
+
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                    columnGap: 3, // Increased gap slightly for better visual separation
+                    rowGap: 0,
+                }}
+            >
+                {overviewItems.map((item) => (
+                    /* --- Step 4: Pass the icon to the component --- */
+                    <KeyValueListItem
+                        key={item.label}
+                        label={item.label}
+                        value={item.value}
+                        isLoading={initialLoading}
+                        icon={item.icon}
+                    />
+                ))}
+            </Box>
+        </Paper>
     );
-  }
-
-
-  return (
-    <Paper variant="outlined" sx={{ p: 2 }}>
-      <Typography
-        variant="h6"
-        sx={{ mb: 1.5, borderBottom: "1px solid #ddd", pb: 1 }}
-      >
-        基本配置
-      </Typography>
-
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <Stack spacing={0}>
-            <KeyValueListItem
-              label="状态"
-              value={overviewData?.status}
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="宿主机"
-              value={overviewData?.hostNode}
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="存储池"
-              value={overviewData?.pool}
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="vCPU 数"
-              value={overviewData?.vcpu?.count}
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="内存总量"
-              value={
-                overviewData?.vram?.total_mb !== undefined
-                  ? `${overviewData.vram.total_mb} MB`
-                  : undefined
-              }
-              isLoading={initialLoading}
-            />
-          </Stack>
-        </Grid>
-
-        <Grid item xs={12} md={6}>
-          <Stack spacing={0}>
-            <KeyValueListItem
-              label="OS 类型"
-              value={overviewData?.osType}
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="持久化"
-              value={
-                overviewData?.persistent === undefined
-                  ? undefined
-                  : overviewData.persistent
-                  ? "是"
-                  : "否"
-              }
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="自动启动"
-              value={
-                overviewData?.autostart === undefined
-                  ? undefined
-                  : overviewData.autostart
-                  ? "是"
-                  : "否"
-              }
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="UUID"
-              value={overviewData?.uuid}
-              isLoading={initialLoading}
-            />
-            <KeyValueListItem
-              label="IP 地址"
-              value={overviewData?.ipAddress}
-              isLoading={initialLoading}
-            />
-          </Stack>
-        </Grid>
-      </Grid>
-    </Paper>
-  );
 }

--- a/src/main_cli_local.py
+++ b/src/main_cli_local.py
@@ -533,7 +533,11 @@ def create_vm(req: VMRequest) -> Dict[str, str | int]:
     return {"vm": vm, "mac": mac, "vnc_port": vnc_port}
 
 
-def get_guac_info(vm_name: str):
+def get_guac_info(vm_name: str, method: str = "ssh"):
+    """Return connection info for the specified protocol."""
+    method = method.lower()
+
+    # default VNC port using XML when not explicitly requested
     try:
         xml = run_virsh("dumpxml", vm_name)
         vnc_port = parse_vnc_port(xml) or 5900
@@ -541,15 +545,29 @@ def get_guac_info(vm_name: str):
         vnc_port = 5900
 
     ip = None
-    try:
-        addr_out = run_virsh("domifaddr", vm_name, "--source", "agent")
-        for line in addr_out.splitlines()[2:]:
-            parts = line.split()
-            if len(parts) >= 4:
-                ip = parts[3]
-                break
-    except RuntimeError:
-        pass
+
+    if method == "vnc":
+        # For VNC connections QEMU usually binds to the host's loopback
+        # interface. The display number returned by ``virsh vncdisplay`` is
+        # converted to the TCP port by adding 5900.
+        ip = "127.0.0.1"
+        try:
+            disp_out = run_virsh("vncdisplay", vm_name).strip()
+            m = re.search(r":(\d+)$", disp_out)
+            if m:
+                vnc_port = 5900 + int(m.group(1))
+        except RuntimeError:
+            pass
+    else:
+        try:
+            addr_out = run_virsh("domifaddr", vm_name, "--source", "agent")
+            for line in addr_out.splitlines()[2:]:
+                parts = line.split()
+                if len(parts) >= 4:
+                    ip = parts[3]
+                    break
+        except RuntimeError:
+            pass
 
     return {
         "host": ip or "192.168.200.10",
@@ -886,7 +904,13 @@ def main():
 
     p_guac = sub.add_parser("guac-info")
     p_guac.add_argument("vm_name")
-    p_guac.set_defaults(func=lambda a: get_guac_info(a.vm_name))
+    p_guac.add_argument(
+        "--method",
+        choices=["ssh", "vnc", "rdp"],
+        default="ssh",
+        help="Guacamole connection type",
+    )
+    p_guac.set_defaults(func=lambda a: get_guac_info(a.vm_name, a.method))
 
     p_get = sub.add_parser("get-vm")
     p_get.add_argument("vm_id")


### PR DESCRIPTION
## Summary
- allow VmController to pass method arg to CLI
- call guac-info with method on frontend
- remove unused console button

## Testing
- `python3 -m py_compile src/main_cli_local.py`
- `npx tsc -p src/tsconfig.json --noEmit` *(fails: Cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686fb9fd91e083208d43870a350fd401