### PR TITLE
Fix VM connection modal

### DIFF
--- a/src/app/AppContent.tsx
+++ b/src/app/AppContent.tsx
@@ -35,12 +35,13 @@ export default function AppContent({ children }: { children: React.ReactNode }) 
   const router = useRouter();
   const pathname = usePathname();
 
-  useEffect(() => {;
+  useEffect(() => {
     const permissionsData = user?.permission || [];
     const roleData = user?.role || [];
     const token = getCookie("_auth");
+    const isGuac = pathname.startsWith('/guac');
     if (!token) {
-      if (pathname !== '/login') {
+      if (pathname !== '/login' && !isGuac) {
         router.replace('/login');
       }
     } else {
@@ -56,7 +57,7 @@ export default function AppContent({ children }: { children: React.ReactNode }) 
   }, [user, pathname, router]);
 
 
-  const showSidebar = Boolean(user) && pathname !== '/login';
+  const showSidebar = Boolean(user) && pathname !== '/login' && !pathname.startsWith('/guac');
 
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh' }}>

--- a/src/app/api/token-guac/route.ts
+++ b/src/app/api/token-guac/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 
 const CIPHER = 'AES-256-CBC';
-const KEY = process.env.GUAC_KEY || '0123456789abcdef0123456789abcdef';
+const KEY = process.env.GUAC_KEY || 'MySuperSecretKeyForParamsToken12';
 
 function encryptToken(value: any) {
   const iv = crypto.randomBytes(16);

--- a/src/app/api/token-guac/route.ts
+++ b/src/app/api/token-guac/route.ts
@@ -19,11 +19,16 @@ export async function GET(req: NextRequest) {
   const type = searchParams.get('type');
   const hostname = searchParams.get('hostname');
   const port = searchParams.get('port');
+  const username = searchParams.get('username');
+  const password = searchParams.get('password');
   if (!type || !hostname || !port) {
     return NextResponse.json({ error: 'Missing params' }, { status: 400 });
   }
+  const settings: Record<string, any> = { hostname, port };
+  if (username) settings.username = username;
+  if (password) settings.password = password;
   const tokenObj = {
-    connection: { type, settings: { hostname, port } }
+    connection: { type, settings }
   };
   const token = encryptToken(tokenObj);
   return NextResponse.json({ token });

--- a/src/app/api/token-guac/route.ts
+++ b/src/app/api/token-guac/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import crypto from 'crypto'
 
-const KEY = Buffer.from(process.env.GUAC_KEY || 'MySuperSecretKeyForParamsToken12')
+const KEY = Buffer.from(process.env.GUAC_KEY || '0123456789abcdef0123456789abcdef')
 
 function generateToken(obj: any) {
   const iv = crypto.randomBytes(16)

--- a/src/app/api/token-guac/route.ts
+++ b/src/app/api/token-guac/route.ts
@@ -1,35 +1,24 @@
-import { NextRequest, NextResponse } from 'next/server';
-import crypto from 'crypto';
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
 
-const CIPHER = 'AES-256-CBC';
-const KEY = process.env.GUAC_KEY || 'MySuperSecretKeyForParamsToken12';
+const KEY = Buffer.from(process.env.GUAC_KEY || 'MySuperSecretKeyForParamsToken12')
 
-function encryptToken(value: any) {
-  const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(CIPHER, Buffer.from(KEY), iv);
-  let encrypted = cipher.update(JSON.stringify(value), 'utf8', 'base64');
-  encrypted += cipher.final('base64');
-  const data = { iv: iv.toString('base64'), value: encrypted };
-  const json = JSON.stringify(data);
-  return Buffer.from(json).toString('base64');
+function generateToken(obj: any) {
+  const iv = crypto.randomBytes(16)
+  const cipher = crypto.createCipheriv('aes-256-cbc', KEY, iv)
+  const ct = Buffer.concat([cipher.update(JSON.stringify(obj), 'utf8'), cipher.final()])
+  const payload = {
+    iv: iv.toString('base64'),
+    value: ct.toString('base64')
+  }
+  return Buffer.from(JSON.stringify(payload)).toString('base64')
 }
 
-export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const type = searchParams.get('type');
-  const hostname = searchParams.get('hostname');
-  const port = searchParams.get('port');
-  const username = searchParams.get('username');
-  const password = searchParams.get('password');
-  if (!type || !hostname || !port) {
-    return NextResponse.json({ error: 'Missing params' }, { status: 400 });
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  if (!data || typeof data !== 'object') {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
   }
-  const settings: Record<string, any> = { hostname, port };
-  if (username) settings.username = username;
-  if (password) settings.password = password;
-  const tokenObj = {
-    connection: { type, settings }
-  };
-  const token = encryptToken(tokenObj);
-  return NextResponse.json({ token });
+  const token = generateToken(data)
+  return NextResponse.json({ token })
 }

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -1,52 +1,166 @@
 'use client'
+import { Suspense, useEffect, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useRef, Suspense } from 'react'
 import Guacamole from 'guacamole-common-js'
 
 export const dynamic = 'force-dynamic'
 
 function GuacInner() {
-  const params = useSearchParams();
-  const type = params.get('type') || '';
-  const hostname = params.get('hostname') || '';
-  const port = params.get('port') || '';
-  const username = params.get('username') || '';
-  const password = params.get('password') || '';
-  const ref = useRef<HTMLDivElement>(null);
+  const params = useSearchParams()
+  const protocol = params.get('type') || params.get('protocol') || 'vnc'
+  const hostname = params.get('hostname') || ''
+  const port = params.get('port') || ''
+  const username = params.get('username') || ''
+  const password = params.get('password') || ''
+
+  const connectionScreenRef = useRef<HTMLDivElement>(null)
+  const displayScreenRef = useRef<HTMLDivElement>(null)
+  const displayRef = useRef<HTMLDivElement>(null)
+  const uuidRef = useRef<HTMLSpanElement>(null)
+
+  const clientRef = useRef<Guacamole.Client | null>(null)
+  const keyboardRef = useRef<Guacamole.Keyboard | null>(null)
+  const pasteListenerRef = useRef<((e: ClipboardEvent) => void) | null>(null)
+
+  const cleanupGuac = () => {
+    const client = clientRef.current
+    if (client) {
+      try { client.disconnect() } catch (_) {}
+      clientRef.current = null
+    }
+    if (uuidRef.current) {
+      uuidRef.current.textContent = ''
+      //@ts-ignore
+      delete uuidRef.current.dataset.uuid
+    }
+    if (keyboardRef.current) {
+      keyboardRef.current.onkeydown = null
+      keyboardRef.current.onkeyup = null
+      keyboardRef.current.reset()
+      keyboardRef.current = null
+    }
+    if (pasteListenerRef.current) {
+      window.removeEventListener('paste', pasteListenerRef.current)
+      pasteListenerRef.current = null
+    }
+  }
+
+  const initializeGuac = (token: string) => {
+    if (!displayRef.current) return
+
+    connectionScreenRef.current!.style.display = 'none'
+    displayScreenRef.current!.style.display = 'flex'
+
+    const wsBase = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host
+    const tunnel = new Guacamole.WebSocketTunnel(wsBase + '/connect-guac')
+
+    tunnel.onuuid = uuid => {
+      if (uuidRef.current) {
+        //@ts-ignore
+        uuidRef.current.dataset.uuid = uuid
+        uuidRef.current.textContent = `ID: ${uuid}`
+      }
+    }
+
+    const client = new Guacamole.Client(tunnel)
+    clientRef.current = client
+    displayRef.current.innerHTML = ''
+    displayRef.current.appendChild(client.getDisplay().getElement())
+
+    client.onerror = err => console.error('Guacamole error', err)
+
+    client.onclipboard = (stream, mimetype) => {
+      let data = ''
+      const reader = new Guacamole.StringReader(stream)
+      reader.ontext = text => { data += text }
+      reader.onend = () => {
+        const textarea = document.getElementById('clipboard-textarea') as HTMLTextAreaElement
+        if (textarea) {
+          textarea.value = data
+          textarea.select()
+          try { document.execCommand('copy') } catch (_) {}
+          window.getSelection()?.removeAllRanges()
+        }
+      }
+    }
+
+    client.onfile = (stream, mimetype, filename) => {
+      stream.sendAck('Ready', Guacamole.Status.Code.SUCCESS)
+      const reader = new Guacamole.BlobReader(stream, mimetype)
+      reader.onend = () => {
+        const file = reader.getBlob()
+        const url = URL.createObjectURL(file)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = filename
+        document.body.appendChild(a)
+        a.click()
+        setTimeout(() => {
+          document.body.removeChild(a)
+          URL.revokeObjectURL(url)
+        }, 100)
+      }
+    }
+
+    const mouse = new Guacamole.Mouse(client.getDisplay().getElement())
+    mouse.onEach(['mousedown','mouseup','mousemove','mousewheel'], e => client.sendMouseState(e.state))
+
+    const keyboard = new Guacamole.Keyboard(window)
+    keyboard.onkeydown = ks => client.sendKeyEvent(1, ks)
+    keyboard.onkeyup = ks => client.sendKeyEvent(0, ks)
+    keyboardRef.current = keyboard
+
+    const pasteListener = (e: ClipboardEvent) => {
+      const text = e.clipboardData?.getData('text/plain')
+      if (text && clientRef.current) {
+        e.preventDefault()
+        const stream = clientRef.current.createClipboardStream('text/plain')
+        const writer = new Guacamole.StringWriter(stream)
+        writer.sendText(text)
+        writer.sendEnd()
+      }
+    }
+    window.addEventListener('paste', pasteListener)
+    pasteListenerRef.current = pasteListener
+
+    client.connect('token=' + encodeURIComponent(token))
+  }
+
+  const connect = async () => {
+    if (!protocol || !hostname || !port) return
+    const q: Record<string,string> = { type: protocol, hostname, port }
+    if (username) q.username = username
+    if (password) q.password = password
+    const qs = new URLSearchParams(q).toString()
+    const res = await fetch('/api/token-guac?' + qs)
+    const data = await res.json()
+    if (!data.token) throw new Error('No token')
+    initializeGuac(data.token)
+  }
 
   useEffect(() => {
-    if (!ref.current || !type || !hostname || !port) return;
-    let client: Guacamole.Client | null = null;
-    let ignore = false;
-    const queryInit: Record<string, string> = { type, hostname, port };
-    if (username) queryInit.username = username;
-    if (password) queryInit.password = password;
-    const qs = new URLSearchParams(queryInit).toString();
-    fetch('/api/token-guac?' + qs)
-      .then(r => r.json())
-      .then(data => {
-        if (ignore || !ref.current || !data.token) return;
-        const wsBase = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host;
-        const ws = wsBase + '/connect-guac?token=' + encodeURIComponent(data.token);
-        const tunnel = new Guacamole.WebSocketTunnel(ws);
-        tunnel.onerror = status => console.error('Tunnel error', status);
-        client = new Guacamole.Client(tunnel);
-        client.onerror = err => console.error('Client error', err);
-        client.onstatechange = state => console.log('Client state', state);
-        ref.current!.innerHTML = '';
-        ref.current!.appendChild(client.getDisplay().getElement());
-        client.connect();
-      });
-    const disconnect = () => client?.disconnect();
-    window.addEventListener('beforeunload', disconnect);
-    return () => {
-      ignore = true;
-      window.removeEventListener('beforeunload', disconnect);
-      client?.disconnect();
-    };
-  }, [type, hostname, port]);
+    if (hostname && port) {
+      connect().catch(err => alert('Connection failed: ' + err.message))
+    }
+    return () => cleanupGuac()
+  }, [protocol, hostname, port, username, password])
 
-  return <div ref={ref} style={{width:'100vw',height:'100vh',background:'#000'}}/>;
+  return (
+    <div id="app-container" className="w-screen h-screen flex flex-col">
+      <div id="connection-screen" ref={connectionScreenRef} className="flex-1 flex items-center justify-center" style={{display:'none'}}>
+        <button id="connect-button" onClick={connect} className="border px-4 py-2">Connect</button>
+      </div>
+      <div id="display-screen" ref={displayScreenRef} className="flex-1 flex-col hidden">
+        <div id="display-header" className="flex items-center gap-2 bg-gray-200 p-2">
+          <div id="display-title" className="flex-1">Remote Connection</div>
+          <span id="display-uuid" ref={uuidRef} className="text-sm cursor-pointer" />
+          <button id="close-button" className="border px-2" onClick={() => { cleanupGuac(); connectionScreenRef.current!.style.display='flex'; displayScreenRef.current!.style.display='none'; }}>Disconnect</button>
+        </div>
+        <div id="display" ref={displayRef} className="flex-1 bg-black" />
+      </div>
+      <textarea id="clipboard-textarea" style={{position:'absolute', left:'-9999px'}} />
+    </div>
+  )
 }
 
 export default function GuacPage() {
@@ -54,5 +168,5 @@ export default function GuacPage() {
     <Suspense>
       <GuacInner />
     </Suspense>
-  );
+  )
 }

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -22,17 +22,12 @@ function GuacInner() {
   const keyboardRef = useRef<Guacamole.Keyboard | null>(null)
   const pasteListenerRef = useRef<((e: ClipboardEvent) => void) | null>(null)
 
-  const cleanupGuac = () => {
-    const client = clientRef.current
-    if (client) {
-      try { client.disconnect() } catch (_) {}
+  function cleanup() {
+    if (clientRef.current) {
+      try { clientRef.current.disconnect() } catch {}
       clientRef.current = null
     }
-    if (uuidRef.current) {
-      uuidRef.current.textContent = ''
-      //@ts-ignore
-      delete uuidRef.current.dataset.uuid
-    }
+    if (uuidRef.current) uuidRef.current.textContent = ''
     if (keyboardRef.current) {
       keyboardRef.current.onkeydown = null
       keyboardRef.current.onkeyup = null
@@ -45,25 +40,19 @@ function GuacInner() {
     }
   }
 
-  const initializeGuac = (token: string) => {
-    if (!displayRef.current) return
+  function init(token: string) {
+    if (!displayRef.current || !displayScreenRef.current || !connectionScreenRef.current) return
 
-    connectionScreenRef.current!.style.display = 'none'
-    displayScreenRef.current!.style.display = 'flex'
+    connectionScreenRef.current.style.display = 'none'
+    displayScreenRef.current.style.display = 'flex'
 
-    const wsBase = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host
-    const tunnel = new Guacamole.WebSocketTunnel(wsBase + '/connect-guac')
-
-    tunnel.onuuid = uuid => {
-      if (uuidRef.current) {
-        //@ts-ignore
-        uuidRef.current.dataset.uuid = uuid
-        uuidRef.current.textContent = `ID: ${uuid}`
-      }
-    }
+    const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/connect-guac'
+    const tunnel = new Guacamole.WebSocketTunnel(wsUrl)
+    tunnel.onuuid = uuid => { if (uuidRef.current) uuidRef.current.textContent = `ID: ${uuid}` }
 
     const client = new Guacamole.Client(tunnel)
     clientRef.current = client
+
     displayRef.current.innerHTML = ''
     displayRef.current.appendChild(client.getDisplay().getElement())
 
@@ -72,13 +61,13 @@ function GuacInner() {
     client.onclipboard = (stream, mimetype) => {
       let data = ''
       const reader = new Guacamole.StringReader(stream)
-      reader.ontext = text => { data += text }
+      reader.ontext = t => { data += t }
       reader.onend = () => {
-        const textarea = document.getElementById('clipboard-textarea') as HTMLTextAreaElement
-        if (textarea) {
-          textarea.value = data
-          textarea.select()
-          try { document.execCommand('copy') } catch (_) {}
+        const ta = document.getElementById('clipboard-textarea') as HTMLTextAreaElement
+        if (ta) {
+          ta.value = data
+          ta.select()
+          try { document.execCommand('copy') } catch {}
           window.getSelection()?.removeAllRanges()
         }
       }
@@ -88,8 +77,8 @@ function GuacInner() {
       stream.sendAck('Ready', Guacamole.Status.Code.SUCCESS)
       const reader = new Guacamole.BlobReader(stream, mimetype)
       reader.onend = () => {
-        const file = reader.getBlob()
-        const url = URL.createObjectURL(file)
+        const blob = reader.getBlob()
+        const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
         a.download = filename
@@ -106,8 +95,8 @@ function GuacInner() {
     mouse.onEach(['mousedown','mouseup','mousemove','mousewheel'], e => client.sendMouseState(e.state))
 
     const keyboard = new Guacamole.Keyboard(window)
-    keyboard.onkeydown = ks => client.sendKeyEvent(1, ks)
-    keyboard.onkeyup = ks => client.sendKeyEvent(0, ks)
+    keyboard.onkeydown = k => client.sendKeyEvent(1, k)
+    keyboard.onkeyup = k => client.sendKeyEvent(0, k)
     keyboardRef.current = keyboard
 
     const pasteListener = (e: ClipboardEvent) => {
@@ -123,38 +112,67 @@ function GuacInner() {
     window.addEventListener('paste', pasteListener)
     pasteListenerRef.current = pasteListener
 
-    client.connect('token=' + encodeURIComponent(token))
-  }
-
-  const connect = async () => {
-    if (!protocol || !hostname || !port) return
-    const q: Record<string,string> = { type: protocol, hostname, port }
-    if (username) q.username = username
-    if (password) q.password = password
-    const qs = new URLSearchParams(q).toString()
-    const res = await fetch('/api/token-guac?' + qs)
-    const data = await res.json()
-    if (!data.token) throw new Error('No token')
-    initializeGuac(data.token)
+    let connectString = `token=${encodeURIComponent(token)}`
+    if (protocol === 'rdp') connectString += '&GUAC_AUDIO=audio/L16'
+    client.connect(connectString)
   }
 
   useEffect(() => {
-    if (hostname && port) {
-      connect().catch(err => alert('Connection failed: ' + err.message))
+    async function connect() {
+      if (!hostname || !port) return
+      const settings: Record<string, any> = { hostname, port }
+      if (username) settings.username = username
+      if (password) settings.password = password
+
+      if (protocol === 'rdp') {
+        Object.assign(settings, {
+          'ignore-cert': true,
+          security: 'any',
+          'enable-drive': true,
+          'drive-path': '/tmp/guac-drive',
+          'create-drive-path': true,
+          'enable-printing': true,
+          audio: ['audio/L16;rate=44100']
+        })
+      }
+      if (protocol === 'vnc') {
+        Object.assign(settings, {
+          autoretry: 3,
+          color_depth: 24,
+          swap_red_blue: false,
+          connect_timeout: 15
+        })
+      }
+      const tokenObj = { connection: { type: protocol, settings } }
+      const res = await fetch('/api/token-guac', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tokenObj)
+      })
+      const data = await res.json()
+      if (!data.token) throw new Error('Token failed')
+      init(data.token)
     }
-    return () => cleanupGuac()
+    connect().catch(err => alert('Connection failed: ' + err.message))
+    return () => cleanup()
   }, [protocol, hostname, port, username, password])
 
   return (
     <div id="app-container" className="w-screen h-screen flex flex-col">
-      <div id="connection-screen" ref={connectionScreenRef} className="flex-1 flex items-center justify-center" style={{display:'none'}}>
-        <button id="connect-button" onClick={connect} className="border px-4 py-2">Connect</button>
+      <div id="connection-screen" ref={connectionScreenRef} className="flex-1 flex items-center justify-center">
+        <div id="connection-form" />
       </div>
       <div id="display-screen" ref={displayScreenRef} className="flex-1 flex-col hidden">
         <div id="display-header" className="flex items-center gap-2 bg-gray-200 p-2">
           <div id="display-title" className="flex-1">Remote Connection</div>
-          <span id="display-uuid" ref={uuidRef} className="text-sm cursor-pointer" />
-          <button id="close-button" className="border px-2" onClick={() => { cleanupGuac(); connectionScreenRef.current!.style.display='flex'; displayScreenRef.current!.style.display='none'; }}>Disconnect</button>
+          <span id="display-uuid" ref={uuidRef} className="text-sm" />
+          <button id="close-button" className="border px-2" onClick={() => {
+            cleanup()
+            if (connectionScreenRef.current && displayScreenRef.current) {
+              connectionScreenRef.current.style.display = 'flex'
+              displayScreenRef.current.style.display = 'none'
+            }
+          }}>Disconnect</button>
         </div>
         <div id="display" ref={displayRef} className="flex-1 bg-black" />
       </div>

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -1,190 +1,67 @@
-'use client'
-import { Suspense, useEffect, useRef } from 'react'
-import { useSearchParams } from 'next/navigation'
-import Guacamole from 'guacamole-common-js'
+"use client";
 
-export const dynamic = 'force-dynamic'
+import { useEffect, useRef } from "react";
+import Guacamole from "guacamole-common-js";
+import crypto from "crypto"; // ⚠️ 注意：这只在 Node.js 里可用
 
-function GuacInner() {
-  const params = useSearchParams()
-  const protocol = params.get('type') || params.get('protocol') || 'vnc'
-  const hostname = params.get('hostname') || ''
-  const port = params.get('port') || ''
-  const username = params.get('username') || ''
-  const password = params.get('password') || ''
+const CIPHER = "aes-256-cbc";
+const SECRET_KEY = "0123456789abcdef0123456789abcdef";
 
-  const connectionScreenRef = useRef<HTMLDivElement>(null)
-  const displayScreenRef = useRef<HTMLDivElement>(null)
-  const displayRef = useRef<HTMLDivElement>(null)
-  const uuidRef = useRef<HTMLSpanElement>(null)
+// 示例连接信息
+const tokenObject = {
+  connection: {
+    type: "vnc",
+    settings: {
+      hostname: "127.0.0.1",
+      port:5900
+    },
+  },
+};
 
-  const clientRef = useRef<Guacamole.Client | null>(null)
-  const keyboardRef = useRef<Guacamole.Keyboard | null>(null)
-  const pasteListenerRef = useRef<((e: ClipboardEvent) => void) | null>(null)
+// ⚠️ 不推荐在前端使用
+function encryptToken(value: object): string {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(CIPHER, Buffer.from(SECRET_KEY), iv);
 
-  function cleanup() {
-    if (clientRef.current) {
-      try { clientRef.current.disconnect() } catch {}
-      clientRef.current = null
-    }
-    if (uuidRef.current) uuidRef.current.textContent = ''
-    if (keyboardRef.current) {
-      keyboardRef.current.onkeydown = null
-      keyboardRef.current.onkeyup = null
-      keyboardRef.current.reset()
-      keyboardRef.current = null
-    }
-    if (pasteListenerRef.current) {
-      window.removeEventListener('paste', pasteListenerRef.current)
-      pasteListenerRef.current = null
-    }
-  }
+  let encrypted = cipher.update(JSON.stringify(value), "utf8", "base64");
+  encrypted += cipher.final("base64");
 
-  function init(token: string) {
-    if (!displayRef.current || !displayScreenRef.current || !connectionScreenRef.current) return
+  const data = {
+    iv: iv.toString("base64"),
+    value: encrypted,
+  };
 
-    connectionScreenRef.current.style.display = 'none'
-    displayScreenRef.current.style.display = 'flex'
-
-    const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/connect-guac'
-    const tunnel = new Guacamole.WebSocketTunnel(wsUrl)
-    tunnel.onuuid = uuid => { if (uuidRef.current) uuidRef.current.textContent = `ID: ${uuid}` }
-
-    const client = new Guacamole.Client(tunnel)
-    clientRef.current = client
-
-    displayRef.current.innerHTML = ''
-    displayRef.current.appendChild(client.getDisplay().getElement())
-
-    client.onerror = err => console.error('Guacamole error', err)
-
-    client.onclipboard = (stream, mimetype) => {
-      let data = ''
-      const reader = new Guacamole.StringReader(stream)
-      reader.ontext = t => { data += t }
-      reader.onend = () => {
-        const ta = document.getElementById('clipboard-textarea') as HTMLTextAreaElement
-        if (ta) {
-          ta.value = data
-          ta.select()
-          try { document.execCommand('copy') } catch {}
-          window.getSelection()?.removeAllRanges()
-        }
-      }
-    }
-
-    client.onfile = (stream, mimetype, filename) => {
-      stream.sendAck('Ready', Guacamole.Status.Code.SUCCESS)
-      const reader = new Guacamole.BlobReader(stream, mimetype)
-      reader.onend = () => {
-        const blob = reader.getBlob()
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = filename
-        document.body.appendChild(a)
-        a.click()
-        setTimeout(() => {
-          document.body.removeChild(a)
-          URL.revokeObjectURL(url)
-        }, 100)
-      }
-    }
-
-    const mouse = new Guacamole.Mouse(client.getDisplay().getElement())
-    mouse.onEach(['mousedown','mouseup','mousemove','mousewheel'], e => client.sendMouseState(e.state))
-
-    const keyboard = new Guacamole.Keyboard(window)
-    keyboard.onkeydown = k => client.sendKeyEvent(1, k)
-    keyboard.onkeyup = k => client.sendKeyEvent(0, k)
-    keyboardRef.current = keyboard
-
-    const pasteListener = (e: ClipboardEvent) => {
-      const text = e.clipboardData?.getData('text/plain')
-      if (text && clientRef.current) {
-        e.preventDefault()
-        const stream = clientRef.current.createClipboardStream('text/plain')
-        const writer = new Guacamole.StringWriter(stream)
-        writer.sendText(text)
-        writer.sendEnd()
-      }
-    }
-    window.addEventListener('paste', pasteListener)
-    pasteListenerRef.current = pasteListener
-
-    let connectString = `token=${encodeURIComponent(token)}`
-    if (protocol === 'rdp') connectString += '&GUAC_AUDIO=audio/L16'
-    client.connect(connectString)
-  }
-
-  useEffect(() => {
-    async function connect() {
-      if (!hostname || !port) return
-      const settings: Record<string, any> = { hostname, port }
-      if (username) settings.username = username
-      if (password) settings.password = password
-
-      if (protocol === 'rdp') {
-        Object.assign(settings, {
-          'ignore-cert': true,
-          security: 'any',
-          'enable-drive': true,
-          'drive-path': '/tmp/guac-drive',
-          'create-drive-path': true,
-          'enable-printing': true,
-          audio: ['audio/L16;rate=44100']
-        })
-      }
-      if (protocol === 'vnc') {
-        Object.assign(settings, {
-          autoretry: 3,
-          color_depth: 24,
-          swap_red_blue: false,
-          connect_timeout: 15
-        })
-      }
-      const tokenObj = { connection: { type: protocol, settings } }
-      const res = await fetch('/api/token-guac', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(tokenObj)
-      })
-      const data = await res.json()
-      if (!data.token) throw new Error('Token failed')
-      init(data.token)
-    }
-    connect().catch(err => alert('Connection failed: ' + err.message))
-    return () => cleanup()
-  }, [protocol, hostname, port, username, password])
-
-  return (
-    <div id="app-container" className="w-screen h-screen flex flex-col">
-      <div id="connection-screen" ref={connectionScreenRef} className="flex-1 flex items-center justify-center">
-        <div id="connection-form" />
-      </div>
-      <div id="display-screen" ref={displayScreenRef} className="flex-1 flex-col hidden">
-        <div id="display-header" className="flex items-center gap-2 bg-gray-200 p-2">
-          <div id="display-title" className="flex-1">Remote Connection</div>
-          <span id="display-uuid" ref={uuidRef} className="text-sm" />
-          <button id="close-button" className="border px-2" onClick={() => {
-            cleanup()
-            if (connectionScreenRef.current && displayScreenRef.current) {
-              connectionScreenRef.current.style.display = 'flex'
-              displayScreenRef.current.style.display = 'none'
-            }
-          }}>Disconnect</button>
-        </div>
-        <div id="display" ref={displayRef} className="flex-1 bg-black" />
-      </div>
-      <textarea id="clipboard-textarea" style={{position:'absolute', left:'-9999px'}} />
-    </div>
-  )
+  const json = JSON.stringify(data);
+  return Buffer.from(json).toString("base64");
 }
 
 export default function GuacPage() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const token = encryptToken(tokenObject); // ⚠️ 实际使用中应从 API 获取
+
+    const tunnel = new Guacamole.WebSocketTunnel("ws://localhost:3001/connect-guac");
+    const client = new Guacamole.Client(tunnel);
+
+    if (containerRef.current) {
+      containerRef.current.appendChild(client.getDisplay().getElement());
+    }
+
+    client.connect("token=" + token);
+
+    window.onunload = () => {
+      client.disconnect();
+    };
+
+    return () => {
+      client.disconnect();
+    };
+  }, []);
+
   return (
-    <Suspense>
-      <GuacInner />
-    </Suspense>
-  )
+      <div style={{ width: "100vw", height: "100vh", backgroundColor: "#000" }}>
+        <div ref={containerRef} style={{ width: "100%", height: "100%" }} />
+      </div>
+  );
 }

--- a/src/app/guac/page.tsx
+++ b/src/app/guac/page.tsx
@@ -10,19 +10,24 @@ function GuacInner() {
   const type = params.get('type') || '';
   const hostname = params.get('hostname') || '';
   const port = params.get('port') || '';
+  const username = params.get('username') || '';
+  const password = params.get('password') || '';
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!ref.current || !type || !hostname || !port) return;
     let client: Guacamole.Client | null = null;
     let ignore = false;
-    const params = new URLSearchParams({ type, hostname, port }).toString();
-    fetch('/api/guac-token?' + params)
+    const queryInit: Record<string, string> = { type, hostname, port };
+    if (username) queryInit.username = username;
+    if (password) queryInit.password = password;
+    const qs = new URLSearchParams(queryInit).toString();
+    fetch('/api/token-guac?' + qs)
       .then(r => r.json())
       .then(data => {
         if (ignore || !ref.current || !data.token) return;
-        const wsBase = window.location.origin.replace(/^http/, 'ws');
-        const ws = wsBase + '/api/guac?token=' + encodeURIComponent(data.token);
+        const wsBase = (window.location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.host;
+        const ws = wsBase + '/connect-guac?token=' + encodeURIComponent(data.token);
         const tunnel = new Guacamole.WebSocketTunnel(ws);
         tunnel.onerror = status => console.error('Tunnel error', status);
         client = new Guacamole.Client(tunnel);

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -205,6 +205,7 @@ export default function VmPage() {
                     ? info.rdp_port
                     : info.vnc_port;
             const url = `/index.html?type=${proto}&hostname=${encodeURIComponent(info.host)}&port=${port}`;
+            //const url = `/guac?type=${proto}&hostname=${encodeURIComponent(info.host)}&port=${port}`;
             window.open(url, '_blank');
         } catch (e: any) {
             alert(e.message || 'Failed to open connection');

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -45,7 +45,6 @@ import StoragePanel from "@/components/vm/StoragePanel";
 import NetworkPanel from "@/components/vm/NetworkPanel";
 import EventsPanel from "@/components/vm/EventsPanel";
 import CreateVmModal from "@/components/vm/CreateVmModal";
-import GuacModal from "@/components/vm/GuacModal";
 
 /* ---------- 类型 ---------- */
 interface VmInstance {
@@ -123,11 +122,6 @@ export default function VmPage() {
     );
     const [actionLoading, setActionLoading] = React.useState(false);
     const [createOpen, setCreateOpen] = React.useState(false);
-    const [guacInfo, setGuacInfo] = React.useState<{
-        type: 'ssh' | 'rdp' | 'vnc';
-        host: string;
-        port: number;
-    } | null>(null);
 
     /* ---- 选中行同步（数据更新后仍保持同一行对象，避免重绘） ---- */
     React.useEffect(() => {
@@ -210,7 +204,8 @@ export default function VmPage() {
                     : proto === 'rdp'
                     ? info.rdp_port
                     : info.vnc_port;
-            setGuacInfo({ type: proto, host: info.host, port: Number(port) });
+            const url = `/guac?type=${proto}&hostname=${encodeURIComponent(info.host)}&port=${port}`;
+            window.open(url, '_blank');
         } catch (e: any) {
             alert(e.message || 'Failed to open connection');
         }
@@ -465,15 +460,6 @@ export default function VmPage() {
                 <CircularProgress color="inherit" />
             </Backdrop>
             <CreateVmModal open={createOpen} onClose={() => setCreateOpen(false)} onCreated={() => mutate()} />
-            {guacInfo && (
-                <GuacModal
-                    open
-                    onClose={() => setGuacInfo(null)}
-                    type={guacInfo.type}
-                    hostname={guacInfo.host}
-                    port={guacInfo.port}
-                />
-            )}
         </Box>
     );
 }

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -204,7 +204,7 @@ export default function VmPage() {
                     : proto === 'rdp'
                     ? info.rdp_port
                     : info.vnc_port;
-            const url = `/guac?type=${proto}&hostname=${encodeURIComponent(info.host)}&port=${port}`;
+            const url = `/index.html?type=${proto}&hostname=${encodeURIComponent(info.host)}&port=${port}`;
             window.open(url, '_blank');
         } catch (e: any) {
             alert(e.message || 'Failed to open connection');

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -9,14 +9,19 @@ html, body {
     margin: 0;
     font-family: Arial, sans-serif;
 }
-#app            { display: flex; flex-direction: column; height: 100%; }
-#toolbar        { height: 48px; background: #222; color: #fff; padding: 0 15px;
-    display: flex; align-items: center; }
-#display        { flex: 1; background: #000;                 /* 画面背景 */
-    display: flex; justify-content: center;    /* 横向居中 */
-    align-items:   center; overflow: hidden; } /* 纵向居中 */
-/* 让 scale 之后以左上角为基准，防止模糊 */
-#display > *    { transform-origin: top left; }
+
+#display{
+    flex-grow:1;
+    width:100%;
+    background:#000;         /* 盖掉白边 */
+    display:flex;            /* 让画面水平垂直居中（可选）*/
+    justify-content:center;
+    align-items:center;
+}
+#display > div {               /* Guacamole 根元素就是 #display 里的第一个 <div> */
+    transform-origin: top left;/* 保证 scale 后 (0,0) 仍是左上角 */
+}
+
 #app-container {
     height: 100%;
     width: 100%;
@@ -144,11 +149,6 @@ button:hover {
     cursor: pointer;
 }
 
-#display {
-    flex-grow: 1;
-    width: 100%;
-    cursor: default;
-}
 
 .guac-hide-cursor {
     cursor: url('data:image/gif;base64,R0lGODlhIAAgAIABAAAAAP///yH5BAEKAAEALAAAAAAgACAAAAIfRI6py+0Po5y02ouz3rz7D4biSJbmIabqyrbuC8dmAQA7'), default;
@@ -330,6 +330,29 @@ const displayUuid = document.getElementById('display-uuid');
 let currentClient = null; // Store the current Guacamole client
 let currentKeyboard = null; // Store the keyboard handler
 let pasteEventListener = null; // Store the paste event listener reference
+let currentScale = 1;
+function fitDisplay() {                    // ← 新增
+    if (!currentClient) return;            // 客户端还没建立时跳过
+    const display = currentClient.getDisplay();
+    const elem    = display.getElement();  // 根 <div>
+    const parent  = elem.parentElement;    // #display
+
+    // 父容器可用尺寸
+    const availW  = parent.clientWidth;
+    const availH  = parent.clientHeight;
+
+    // 远端实际分辨率
+    const remoteW = display.getWidth();
+    const remoteH = display.getHeight();
+    if (!remoteW || !remoteH) return;      // 远端还没回报分辨率
+
+    // 取最小比例，保证完整显示
+    const scale   = Math.min(availW / remoteW, availH / remoteH);
+
+    // 让 Guacamole 做缩放，同时修正鼠标坐标
+    display.scale(scale);
+    currentScale = scale;
+}
 
 // Helper function to get selected radio value
 function getSelectedRadioValue(name) {
@@ -525,7 +548,10 @@ function initializeGuacamoleClient(token, protocol) {
         // Add client display to the page
         const displayDiv = document.getElementById("display");
         displayDiv.appendChild(client.getDisplay().getElement());
-
+        // 绑定缩放逻辑
+        client.getDisplay().onresize = fitDisplay; // 远端分辨率变化时
+        fitDisplay();                              // 首次连接立即适配
+        window.addEventListener('resize', fitDisplay); // 浏览器窗口变化时
         // Set up error handler
         client.onerror = function (error) {
             console.error("Guacamole error:", error);
@@ -595,9 +621,16 @@ function initializeGuacamoleClient(token, protocol) {
 
         // Set up mouse
         const mouse = new Guacamole.Mouse(client.getDisplay().getElement());
-        mouse.onEach(['mousedown', 'mouseup', 'mousemove', 'mousewheel'],
-            e => client.sendMouseState(e.state));
-
+        //mouse.onEach(['mousedown', 'mouseup', 'mousemove', 'mousewheel'],
+        //    e => client.sendMouseState(e.state));
+        mouse.onEach(['mousedown','mouseup','mousemove','mousewheel'], e => {
+            const fixed = {
+                ...e.state,
+                x: Math.round(e.state.x / currentScale),
+                y: Math.round(e.state.y / currentScale)
+            };
+            client.sendMouseState(fixed);
+        });
         // Set up keyboard
         const keyboard = new Guacamole.Keyboard(window);
         keyboard.onkeydown = keysym => client.sendKeyEvent(1, keysym);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1,0 +1,745 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>guacamole-lite test</title>
+<style>
+html, body {
+    height: 100%;
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+#app            { display: flex; flex-direction: column; height: 100%; }
+#toolbar        { height: 48px; background: #222; color: #fff; padding: 0 15px;
+    display: flex; align-items: center; }
+#display        { flex: 1; background: #000;                 /* 画面背景 */
+    display: flex; justify-content: center;    /* 横向居中 */
+    align-items:   center; overflow: hidden; } /* 纵向居中 */
+/* 让 scale 之后以左上角为基准，防止模糊 */
+#display > *    { transform-origin: top left; }
+#app-container {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+#connection-screen {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: flex-start;
+    align-items: center;
+    background-color: #f5f5f5;
+    padding-top: 60px;
+    box-sizing: border-box;
+}
+
+#connection-form {
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    padding: 25px;
+    width: 90%;
+    max-width: 600px;
+}
+
+.form-header {
+    text-align: center;
+    margin-bottom: 20px;
+    color: #333;
+}
+
+.form-row {
+    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column;
+}
+
+#remote-host-details {
+    display: none;
+    flex-direction: column;
+    gap: 15px;
+}
+
+#remote-host-details.visible {
+    display: flex;
+}
+
+#join-connection-details {
+    display: none;
+    flex-direction: column;
+    gap: 15px;
+}
+
+#join-connection-details.visible {
+    display: flex;
+}
+
+label {
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: #555;
+}
+
+input, select {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+button {
+    padding: 12px 20px;
+    background-color: #4285f4;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background-color: #3367d6;
+}
+
+#display-screen {
+    display: none;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+#display-header {
+    display: flex;
+    padding: 10px;
+    background-color: #333;
+    color: white;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#display-title {
+    font-weight: bold;
+}
+
+#display-uuid {
+    margin-left: 15px;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #aee;
+}
+
+#display-uuid:hover {
+    text-decoration: underline;
+}
+
+#close-button {
+    padding: 8px 15px;
+    background-color: #f44336;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+#display {
+    flex-grow: 1;
+    width: 100%;
+    cursor: default;
+}
+
+.guac-hide-cursor {
+    cursor: url('data:image/gif;base64,R0lGODlhIAAgAIABAAAAAP///yH5BAEKAAEALAAAAAAgACAAAAIfRI6py+0Po5y02ouz3rz7D4biSJbmIabqyrbuC8dmAQA7'), default;
+}
+
+/* Radio button styles */
+.radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.radio-option {
+    display: flex;
+    align-items: center;
+}
+
+.radio-option label {
+    margin-left: 8px;
+    margin-bottom: 0;
+    cursor: pointer;
+}
+
+/* Checkbox styles */
+.checkbox-option {
+    display: flex;
+    align-items: center;
+}
+
+.checkbox-option input[type="checkbox"] {
+    margin-right: 8px;
+    cursor: pointer;
+}
+
+.checkbox-option label {
+    margin-bottom: 0;
+    cursor: pointer;
+    font-weight: normal;
+} 
+</style>
+</head>
+<body>
+<div id="app-container">
+    <!-- Connection Screen -->
+    <div id="connection-screen">
+        <div id="connection-form">
+            <h2 class="form-header">Guacamole Remote Connection</h2>
+
+            <div class="form-row">
+                <label>Connection Type:</label>
+                <div id="connection-type" class="radio-group">
+                    <div class="radio-option">
+                        <input type="radio" id="connection-type-new" name="connection-type" value="new">
+                        <label for="connection-type-new">New Connection</label>
+                    </div>
+                    <div class="radio-option">
+                        <input type="radio" id="connection-type-join" name="connection-type" value="join">
+                        <label for="connection-type-join">Join Connection</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-row">
+                <label>Protocol:</label>
+                <div id="protocol" class="radio-group">
+                    <div class="radio-option">
+                        <input type="radio" id="protocol-rdp" name="protocol" value="rdp" checked>
+                        <label for="protocol-rdp">RDP</label>
+                    </div>
+                    <div class="radio-option">
+                        <input type="radio" id="protocol-vnc" name="protocol" value="vnc">
+                        <label for="protocol-vnc">VNC</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-row">
+                <label>Connect to:</label>
+                <div id="connect-target" class="radio-group">
+                    <div class="radio-option">
+                        <input type="radio" id="connect-target-test" name="connect-target" value="test-host" checked>
+                        <label for="connect-target-test">Test Host</label>
+                    </div>
+                    <div class="radio-option">
+                        <input type="radio" id="connect-target-remote" name="connect-target" value="remote-host">
+                        <label for="connect-target-remote">Remote Host</label>
+                    </div>
+                </div>
+            </div>
+
+            <div id="remote-host-details">
+                <div class="form-row">
+                    <label for="remote-hostname">Host:</label>
+                    <input type="text" id="remote-hostname" placeholder="hostname or IP">
+                </div>
+                <div class="form-row">
+                    <label for="remote-username">Username:</label>
+                    <input type="text" id="remote-username">
+                </div>
+                <div class="form-row">
+                    <label for="remote-password">Password:</label>
+                    <input type="password" id="remote-password">
+                </div>
+            </div>
+
+            <div id="join-connection-details">
+                <div class="form-row">
+                    <label for="connection-id">Connection ID:</label>
+                    <input type="text" id="connection-id" placeholder="Enter connection ID to join">
+                </div>
+                <div class="form-row">
+                    <div class="checkbox-option">
+                        <input type="checkbox" id="read-only" value="true">
+                        <label for="read-only">Read-only mode</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-row" style="margin-top: 20px;">
+                <button id="connect-button">Connect</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Display Screen -->
+    <div id="display-screen">
+        <div id="display-header">
+            <div id="display-title">Remote Connection</div>
+            <span id="display-uuid" title="Click to copy Connection ID"></span>
+            <button id="close-button">Disconnect</button>
+        </div>
+        <!-- The remote-desktop surface -->
+        <div id="display"></div>
+    </div>
+</div>
+
+<!-- Hidden textarea for clipboard integration -->
+<textarea id="clipboard-textarea" style="position: absolute; left: -9999px;"></textarea>
+
+<script src="https://cdn.jsdelivr.net/npm/guacamole-common-js@1.5.0/dist/cjs/guacamole-common.min.js"></script>
+<script>
+async function generateGuacamoleToken(tokenObj) {
+  /* ------------ demo-only token generation (do this in backend IRL) --- */
+  const CIPHER = 'AES-256-CBC';
+  const KEY = new TextEncoder().encode('0123456789abcdef0123456789abcdef');
+
+  const iv   = crypto.getRandomValues(new Uint8Array(16));
+  const algo = { name: "AES-CBC", iv };
+  const key  = await crypto.subtle.importKey("raw", KEY, algo, false, ["encrypt"]);
+  const ct   = new Uint8Array(await crypto.subtle.encrypt(algo, key,
+                      new TextEncoder().encode(JSON.stringify(tokenObj))));
+
+  const token = btoa(JSON.stringify({
+    iv:    btoa(String.fromCharCode(...iv)),
+    value: btoa(String.fromCharCode(...ct))
+  }));
+
+  return token;
+} 
+</script>
+<script>
+// DOM elements
+const connectionScreen = document.getElementById('connection-screen');
+const displayScreen = document.getElementById('display-screen');
+const connectTargetRadios = document.querySelectorAll('input[name="connect-target"]');
+const remoteHostDetailsDiv = document.getElementById('remote-host-details');
+const connectButton = document.getElementById('connect-button');
+const closeButton = document.getElementById('close-button');
+const protocolRadios = document.querySelectorAll('input[name="protocol"]');
+const connectionTypeRadios = document.querySelectorAll('input[name="connection-type"]');
+const remoteHostnameInput = document.getElementById('remote-hostname');
+const remoteUsernameInput = document.getElementById('remote-username');
+const remotePasswordInput = document.getElementById('remote-password');
+const joinConnectionDetailsDiv = document.getElementById('join-connection-details');
+const connectionIdInput = document.getElementById('connection-id');
+const readOnlyCheckbox = document.getElementById('read-only');
+const displayUuid = document.getElementById('display-uuid');
+
+let currentClient = null; // Store the current Guacamole client
+let currentKeyboard = null; // Store the keyboard handler
+let pasteEventListener = null; // Store the paste event listener reference
+
+// Helper function to get selected radio value
+function getSelectedRadioValue(name) {
+    const el = document.querySelector(`input[name="${name}"]:checked`);
+    return el ? el.value : null;
+}
+
+// Centralised form visibility handler ----------------------------------
+function updateFormVisibility() {
+    const mode = getSelectedRadioValue('connection-type');
+
+    if (!mode) {
+        // Nothing selected – hide everything except connection-type row
+        document.getElementById('connect-target').closest('.form-row').style.display = 'none';
+        document.getElementById('protocol').closest('.form-row').style.display = 'none';
+        remoteHostDetailsDiv.classList.remove('visible');
+        joinConnectionDetailsDiv.classList.remove('visible');
+        joinConnectionDetailsDiv.hidden = true;
+        return;
+    }
+
+    if (mode === 'join') {
+        // Hide everything related to new connections
+        document.getElementById('connect-target').closest('.form-row').style.display = 'none';
+        document.getElementById('protocol').closest('.form-row').style.display = 'none';
+        remoteHostDetailsDiv.classList.remove('visible');
+
+        // Show join-specific section
+        joinConnectionDetailsDiv.classList.add('visible');
+        joinConnectionDetailsDiv.hidden = false;
+    } else {
+        // Show new-connection inputs
+        document.getElementById('connect-target').closest('.form-row').style.display = '';
+        document.getElementById('protocol').closest('.form-row').style.display = '';
+        joinConnectionDetailsDiv.classList.remove('visible');
+        joinConnectionDetailsDiv.hidden = true;
+
+        // Show remote host details only when "Remote Host" is chosen
+        if (getSelectedRadioValue('connect-target') === 'remote-host') {
+            remoteHostDetailsDiv.classList.add('visible');
+            remoteHostDetailsDiv.hidden = false;
+        } else {
+            remoteHostDetailsDiv.classList.remove('visible');
+            remoteHostDetailsDiv.hidden = true;
+        }
+    }
+}
+
+// Bind the visibility handler to all relevant radio groups
+[...connectionTypeRadios, ...connectTargetRadios, ...protocolRadios].forEach(radio => {
+    radio.addEventListener('change', updateFormVisibility);
+});
+
+// Initialise form visibility on page load
+updateFormVisibility();
+
+// Connect button click handler
+connectButton.addEventListener('click', async () => {
+    const mode = getSelectedRadioValue('connection-type');
+    let tokenObj;
+    let protocol = null;
+
+    if (mode === 'join') {
+        // Handle joining an existing connection
+        const connectionId = connectionIdInput.value.trim();
+        if (!connectionId) {
+            alert('Please enter a connection ID to join');
+            return;
+        }
+
+        tokenObj = {
+            connection: {
+                join: connectionId,
+                settings: {
+                    'read-only': readOnlyCheckbox.checked
+                }
+            }
+        };
+    } else {
+        protocol = getSelectedRadioValue('protocol');
+        if (!protocol) {
+            alert('Please select a protocol');
+            return;
+        }
+        // Handle regular connection
+        const target = getSelectedRadioValue('connect-target');
+        let connectionSettings;
+
+        // Base connection settings
+        connectionSettings = {
+            hostname: target === 'test-host' ? 'desktop-linux' : remoteHostnameInput.value,
+            username: target === 'test-host' ? 'testuser' : remoteUsernameInput.value,
+            password: target === 'test-host' ? 'Passw0rd!' : remotePasswordInput.value,
+        };
+
+        if (protocol === 'rdp') {
+            Object.assign(connectionSettings, {
+                "ignore-cert": true,
+                "security": "any",
+                "enable-drive": true,
+                "drive-path": "/tmp/guac-drive",
+                "create-drive-path": true,
+                "enable-printing": true,
+                "audio": ["audio/L16;rate=44100"]
+            });
+        }
+
+        // Add VNC-specific settings
+        if (protocol === 'vnc') {
+            Object.assign(connectionSettings, {
+                port: 5900,
+                autoretry: 3,
+                color_depth: 24,
+                swap_red_blue: false,
+                connect_timeout: 15
+            });
+        }
+
+        tokenObj = {
+            connection: {
+                type: protocol,
+                settings: connectionSettings
+            }
+        };
+    }
+
+    try {
+        // Clear previous display if any
+        const displayDiv = document.getElementById('display');
+        while (displayDiv.firstChild) {
+            displayDiv.removeChild(displayDiv.firstChild);
+        }
+
+        console.log("Generating token for:", tokenObj);
+        if (mode === 'join') {
+            console.log(`Joining existing connection: ${tokenObj.connection.join}, read-only: ${tokenObj.connection.settings['read-only']}`);
+        } else {
+            const settings = tokenObj.connection.settings;
+            console.log(`Connecting with ${protocol.toUpperCase()} to ${settings.hostname}:${settings.port || (protocol === 'rdp' ? '3389' : '5900')}`);
+        }
+        const token = await generateGuacamoleToken(tokenObj);
+        console.log("Token generated, initializing Guacamole...");
+
+        // Initialize Guacamole client
+        initializeGuacamoleClient(token, mode === 'join' ? 'join' : protocol);
+    } catch (error) {
+        console.error("Failed to connect:", error);
+        alert("Connection failed: " + error.message);
+
+        // Switch back to connection screen on error
+        displayScreen.style.display = 'none';
+        connectionScreen.style.display = 'flex';
+    }
+});
+
+// Function to initialize Guacamole client
+function initializeGuacamoleClient(token, protocol) {
+    // Switch to display screen before initializing to avoid UI jumping
+    connectionScreen.style.display = 'none';
+    displayScreen.style.display = 'flex';
+
+    // Update display title with connection info
+    const displayTitle = document.getElementById('display-title');
+    if (protocol === 'join') {
+        const connectionId = connectionIdInput.value.trim();
+        const readOnly = readOnlyCheckbox.checked ? ' (read-only)' : '';
+        displayTitle.textContent = `Joined connection: ${connectionId}${readOnly}`;
+    } else {
+        const target = getSelectedRadioValue('connect-target');
+        displayTitle.textContent = `Connected to: ${target === 'test-host' ? 'Test Host' : remoteHostnameInput.value} (${protocol.toUpperCase()})`;
+    }
+
+    try {
+        // Create WebSocket tunnel
+        const tunnel = new Guacamole.WebSocketTunnel(`ws://localhost:3001/connect-guac`);
+
+        // Set up onuuid event handler to log connection ID
+        tunnel.onuuid = function (uuid) {
+            console.log("Connection UUID received:", uuid);
+            console.log("This UUID can be used to join this session from another client");
+
+            // Show UUID in the header and store for copying
+            if (displayUuid) {
+                displayUuid.dataset.uuid = uuid;
+                displayUuid.textContent = `ID: ${uuid}`;
+            }
+        };
+
+        // Create client
+        const client = new Guacamole.Client(tunnel);
+        currentClient = client;
+
+        // Add client display to the page
+        const displayDiv = document.getElementById("display");
+        displayDiv.appendChild(client.getDisplay().getElement());
+
+        // Set up error handler
+        client.onerror = function (error) {
+            console.error("Guacamole error:", error);
+            let errorMessage = error.message || "Unknown error";
+
+            // Enhanced error messages for common issues
+            if (protocol === 'vnc' && errorMessage.includes("connect")) {
+                errorMessage = "VNC Connection Error: Could not connect to VNC server. Please verify the host is running a VNC server on port 5900.";
+            } else if (protocol === 'rdp' && errorMessage.includes("connect")) {
+                errorMessage = "RDP Connection Error: Could not connect to RDP server. Please verify the host is running and accepting RDP connections.";
+            }
+
+            alert("Guacamole error: " + errorMessage);
+        };
+
+        // Set up clipboard handler
+        client.onclipboard = (stream, mimetype) => {
+            let data = '';
+            const reader = new Guacamole.StringReader(stream);
+            reader.ontext = text => data += text;
+            reader.onend = () => {
+                console.log("Clipboard data received:", data);
+                // Update the hidden textarea and trigger copy
+                const textarea = document.getElementById('clipboard-textarea');
+                if (textarea) {
+                    textarea.value = data;
+                    textarea.select();
+                    try {
+                        const successful = document.execCommand('copy');
+                        const msg = successful ? 'successful' : 'unsuccessful';
+                        console.log('Copying text command was ' + msg);
+                    } catch (err) {
+                        console.error('Failed to copy text: ', err);
+                    }
+                    // Deselect the text to avoid visual artifacts
+                    window.getSelection().removeAllRanges();
+                }
+            };
+        };
+
+        // Set up file download handler
+        client.onfile = (stream, mimetype, filename) => {
+            stream.sendAck("Ready", Guacamole.Status.Code.SUCCESS);
+
+            const reader = new Guacamole.BlobReader(stream, mimetype);
+
+            reader.onprogress = (length) => {
+                console.log(`Downloaded ${length} bytes of ${filename}`);
+            };
+
+            reader.onend = () => {
+                // Automatically create a link and download the file
+                const file = reader.getBlob();
+                const url = URL.createObjectURL(file);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = filename;
+                document.body.appendChild(a);
+                a.click();
+                setTimeout(() => {
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+                    console.log(`File download complete: ${filename}`);
+                }, 100);
+            };
+        };
+
+        // Set up mouse
+        const mouse = new Guacamole.Mouse(client.getDisplay().getElement());
+        mouse.onEach(['mousedown', 'mouseup', 'mousemove', 'mousewheel'],
+            e => client.sendMouseState(e.state));
+
+        // Set up keyboard
+        const keyboard = new Guacamole.Keyboard(window);
+        keyboard.onkeydown = keysym => client.sendKeyEvent(1, keysym);
+        keyboard.onkeyup = keysym => client.sendKeyEvent(0, keysym);
+        currentKeyboard = keyboard;
+
+        // Set up paste event listener
+        pasteEventListener = (event) => {
+            const text = event.clipboardData.getData('text/plain');
+            if (text && currentClient) {
+                event.preventDefault(); // Prevent default paste behavior in browser
+                // Send clipboard data to the remote session
+                const stream = currentClient.createClipboardStream('text/plain');
+                const writer = new Guacamole.StringWriter(stream);
+                writer.sendText(text);
+                writer.sendEnd();
+                console.log("Sent clipboard data to remote:", text);
+            }
+        };
+        window.addEventListener('paste', pasteEventListener);
+
+        // Connect to the remote desktop
+        // Construct connection string, adding audio only if RDP
+        let connectString = `token=${encodeURIComponent(token)}`;
+        if (protocol === 'rdp') {
+            connectString += `&GUAC_AUDIO=audio/L16`;
+        }
+        client.connect(connectString);
+
+        console.log("Guacamole client initialized and connected");
+    } catch (error) {
+        // Clean up any partially created resources
+        cleanupGuacamole();
+
+        // Show error and return to connection screen
+        console.error("Error initializing Guacamole:", error);
+        alert("Error initializing Guacamole: " + error.message);
+        displayScreen.style.display = 'none';
+        connectionScreen.style.display = 'flex';
+    }
+}
+
+// Close button click handler
+closeButton.addEventListener('click', () => {
+    cleanupGuacamole();
+
+    // Switch back to connection screen
+    displayScreen.style.display = 'none';
+    connectionScreen.style.display = 'flex';
+});
+
+// Function to properly clean up all Guacamole resources
+function cleanupGuacamole() {
+    if (currentClient) {
+        // Disconnect the client
+        try {
+            currentClient.disconnect();
+        } catch (e) {
+            console.error("Error disconnecting client:", e);
+        }
+        currentClient = null;
+    }
+
+    // Clear displayed UUID
+    if (displayUuid) {
+        displayUuid.textContent = '';
+        delete displayUuid.dataset.uuid;
+    }
+
+    // Properly detach keyboard handler
+    if (currentKeyboard) {
+        try {
+            // Remove existing handlers
+            currentKeyboard.onkeydown = null;
+            currentKeyboard.onkeyup = null;
+
+            // Reset the keyboard state completely
+            currentKeyboard.reset();
+        } catch (e) {
+            console.error("Error cleaning up keyboard:", e);
+        }
+        currentKeyboard = null;
+    }
+
+    // Remove paste event listener if it exists
+    if (pasteEventListener) {
+        window.removeEventListener('paste', pasteEventListener);
+        pasteEventListener = null;
+    }
+
+    // Allow a brief moment for cleanup before making inputs focusable
+    setTimeout(() => {
+        // Re-focus on a form element to help ensure keyboard is working
+        const firstInput = document.querySelector('#connection-form input, #connection-form select');
+        if (firstInput) {
+            firstInput.focus();
+        }
+    }, 100);
+}
+
+// Add click-to-copy behavior for UUID
+if (displayUuid) {
+    displayUuid.addEventListener('click', () => {
+        const uuid = displayUuid.dataset.uuid;
+        if (!uuid) return;
+
+        // Use Clipboard API if available, fallback to old execCommand
+        const copyPromise = navigator.clipboard
+            ? navigator.clipboard.writeText(uuid)
+            : new Promise((resolve, reject) => {
+                  const textarea = document.createElement('textarea');
+                  textarea.value = uuid;
+                  textarea.style.position = 'fixed';
+                  textarea.style.left = '-9999px';
+                  document.body.appendChild(textarea);
+                  textarea.select();
+                  try {
+                      document.execCommand('copy');
+                      resolve();
+                  } catch (err) {
+                      reject(err);
+                  } finally {
+                      document.body.removeChild(textarea);
+                  }
+              });
+
+        copyPromise
+            .then(() => {
+                const original = displayUuid.textContent;
+                displayUuid.textContent = 'Copied!';
+                setTimeout(() => {
+                    displayUuid.textContent = original;
+                }, 1500);
+            })
+            .catch(err => console.error('Failed to copy UUID:', err));
+    });
+}
+
+// Handle page unloads to clean up any active sessions
+window.addEventListener('beforeunload', () => {
+    cleanupGuacamole();
+}); 
+</script>
+</body>
+</html>

--- a/src/server.js
+++ b/src/server.js
@@ -87,7 +87,7 @@ app.prepare().then(() => {
           vnc: ['hostname', 'port', 'password'],
           join: ['id','width','height','dpi']
         },
-        log: { level: 'VERBOSE' },
+        log: { level: 'DEBUG' },
       }
   );
   guacServer.on('open', c => console.log('[Guac OPEN]', c.connectionId));

--- a/src/server.js
+++ b/src/server.js
@@ -78,6 +78,9 @@ app.prepare().then(() => {
       { port: 4822 },
       {
         crypt: { cypher: 'AES-256-CBC', key: GUAC_KEY },
+        connectionDefaultSettings: {
+          rdp: { 'audio': ['audio/L16'] }
+        },
         allowedUnencryptedConnectionSettings: {
           rdp: ['hostname', 'port', 'username', 'password', 'security', 'ignore-cert'],
           ssh: ['hostname', 'port', 'username', 'password'],


### PR DESCRIPTION
## Summary
- open remote console in a new page instead of a modal
- skip auth and sidebar for `/guac` pages
- allow optional username/password in guac token API
- update client guac page to use new API

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872186514c48320a1dd7b66d728c747