### PR TITLE
Implement VM and container cleanup

### DIFF
--- a/back/app/Http/Controllers/Vm/MainCli/VmController.php
+++ b/back/app/Http/Controllers/Vm/MainCli/VmController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Vm\MainCli;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use App\Models\scenario\SceneVmInstance;
 use Symfony\Component\Process\Process;
 use Illuminate\Support\Str;
 
@@ -757,7 +759,7 @@ class VmController extends Controller
     }
 
     // DELETE /vms/{vm_id}
-    public function deleteVm($vmId)
+    public function deleteVm(Request $request, $vmId)
     {
         try {
             try { $this->runVirsh('destroy', $vmId); } catch (\Throwable $e) {}
@@ -765,6 +767,16 @@ class VmController extends Controller
         } catch (\Throwable $e) {
             return response()->json(['error' => $e->getMessage()], 500);
         }
+
+        $domain = $request->input('domain_name');
+        if ($domain) {
+            try {
+                SceneVmInstance::where('c_vm_name', $domain)->delete();
+            } catch (\Throwable $e) {
+                Log::error('Failed to delete VM record: ' . $e->getMessage(), ['domain' => $domain]);
+            }
+        }
+
         return response()->json(['message' => 'deleted'], 200);
     }
 }

--- a/back/app/Services/DockerService.php
+++ b/back/app/Services/DockerService.php
@@ -9,6 +9,8 @@ use Docker\API\Model\HostConfig;
 use Docker\API\Model\PortBinding;
 use Docker\API\Model\ContainerConfigExposedPortsItem;
 use App\Models\Docker\DockerInstanceModel;
+use App\Models\scenario\SceneContainerInstance;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -141,6 +143,12 @@ class DockerService
     public function removeContainer(string $id)
     {
         $this->docker->containerDelete($id, ['force' => true]);
+
+        try {
+            SceneContainerInstance::where('c_container_id', $id)->delete();
+        } catch (\Throwable $e) {
+            Log::error('Failed to delete container record: ' . $e->getMessage(), ['id' => $id]);
+        }
     }
 
     public function removeImage(string $id)

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -369,7 +369,7 @@ export default function VmPage() {
         if (!window.confirm(`确定删除虚拟机 ${vm.name}？`)) return;
         setActionLoading(true);
         try {
-            const res = await fetch(`/back/api/vms/${vm.id}`, { method: 'DELETE' });
+            const res = await fetch(`/back/api/vms/${vm.id}?domain_name=${encodeURIComponent(vm.name)}`, { method: 'DELETE' });
             if (!res.ok) {
                 const err = await res.json().catch(() => ({}));
                 throw new Error(err.detail || res.statusText);


### PR DESCRIPTION
## Summary
- remove records on container deletion
- delete VM instance entry when removing VM and accept domain name
- send VM domain name from vm-instances page when deleting

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: ErrorException: Trying to access array offset on null)*

------
https://chatgpt.com/codex/tasks/task_e_6879ecb5ac1c8320a4a1f3e01345256a