### PR TITLE
Enable VM image deletion and simplify table

### DIFF
--- a/back/app/Http/Controllers/Vm/MainCli/VmController.php
+++ b/back/app/Http/Controllers/Vm/MainCli/VmController.php
@@ -267,6 +267,18 @@ class VmController extends Controller
         return response()->json($data, 200);
     }
 
+    // DELETE /vms/images/{image}
+    public function deleteVmImage($image)
+    {
+        try {
+            $this->runVirsh('vol-delete', $image, '--pool', 'default');
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
+
+        return response()->json(['message' => 'deleted'], 200);
+    }
+
     // POST /vms/create
     public function createVm(Request $request)
     {

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -186,6 +186,7 @@ use Illuminate\Support\Facades\Route;
         $c = \App\Http\Controllers\Vm\MainCli\VmController::class;
         Route::get('/', [$c, 'listVms']);
         Route::get('/images', [$c, 'listVmImages']);
+        Route::delete('/images/{image}', [$c, 'deleteVmImage']);
         Route::post('/create', [$c, 'createVm']);
         Route::get('/{vm_name}/guac', [$c, 'getGuacInfo']);
         Route::get('/{vm_id}', [$c, 'getVmInfo']);

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -23,7 +23,6 @@ import {
     useTheme,
 } from "@mui/material"
 import {
-    Edit as EditIcon,
     Delete as DeleteIcon,
     PlayArrow as StartIcon,
     CloudUpload as UploadIcon,
@@ -131,9 +130,13 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
         img.description?.toLowerCase().includes(search.toLowerCase())
     )
 
-    const handleDelete = (id: string) => {
-        if (confirm("确定要删除这个虚拟机镜像吗？")) {
+    const handleDelete = async (id: string) => {
+        if (!confirm("确定要删除这个虚拟机镜像吗？")) return
+        try {
+            await fetch(`/back/api/vms/images/${id}`, { method: 'DELETE' })
             setImages((prev) => prev.filter((img) => img.id !== id))
+        } catch {
+            alert('删除失败')
         }
     }
 
@@ -165,7 +168,6 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
 
     const columns = useMemo<GridColDef[]>(() => [
         { field: 'name', headerName: '名称', flex: 1, minWidth: 160 },
-        { field: 'description', headerName: '描述', flex: 1, minWidth: 200 },
         { field: 'size', headerName: '大小', width: 120 },
         {
             field: 'status',
@@ -195,11 +197,6 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
                     <Tooltip title="启动">
                         <IconButton size="small" onClick={() => handleStart(params.row)}>
                             <StartIcon color="success" />
-                        </IconButton>
-                    </Tooltip>
-                    <Tooltip title="编辑">
-                        <IconButton size="small" onClick={() => handleOpenDialog(params.row)}>
-                            <EditIcon />
                         </IconButton>
                     </Tooltip>
                     <Tooltip title="删除">


### PR DESCRIPTION
## Summary
- remove description column from VM images page and drop edit icon
- call backend API when deleting VM image
- add `deleteVmImage` route and controller method

## Testing
- `composer install`
- `php artisan test` *(fails: the application returns a successful response)*

------
https://chatgpt.com/codex/tasks/task_e_6879f3f273488320a489bc00d47bb197