### PR TITLE
Fix VM IP retrieval for Guacamole

### DIFF
--- a/back/app/Http/Controllers/Docker/InstancesController.php
+++ b/back/app/Http/Controllers/Docker/InstancesController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Request;
 use App\Services\DockerService;
 use App\Models\Docker\Instance;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class InstancesController extends Controller
 {
@@ -33,6 +35,25 @@ class InstancesController extends Controller
         $role = $request->query('role', 'student');
         $userId = $request->query('userId');
         $containers = $this->docker->listContainers();
+
+        // Fetch extra info from DB: IP, scene instance and scene name
+        $ids = array_map(fn($c) => $c->getId(), $containers);
+        $extra = [];
+        if ($ids) {
+            try {
+                $extra = DB::table('c_scene_container_instances as c')
+                    ->leftJoin('c_scene_instances as si', DB::raw('c.c_scene_instances_id COLLATE utf8mb4_unicode_ci'), '=', 'si.c_scene_instances_id')
+                    ->leftJoin('c_scene_configs as sc', 'si.c_config_id', '=', 'sc.c_config_id')
+                    ->select('c.c_container_id', 'c.c_scene_instances_id', 'c.c_ip', 'sc.c_name as scene_name')
+                    ->whereIn('c.c_container_id', $ids)
+                    ->get()
+                    ->keyBy('c_container_id');
+            } catch (\Throwable $e) {
+                Log::error('DB query failed in container index: ' . $e->getMessage());
+                $extra = [];
+            }
+        }
+
         $result = [];
         foreach ($containers as $info) {
             $labels = $info->getLabels() ?? [];
@@ -87,6 +108,10 @@ class InstancesController extends Controller
                 }
             }
 
+            $infoExtra = $extra[$info->getId()] ?? null;
+            $ip = $infoExtra->c_ip ?? null;
+            if ($ip) $ip = explode('/', $ip)[0];
+
             $result[] = [
                 'id' => $info->getId(),
                 'name' => ltrim($info->getNames()[0] ?? substr($info->getId(),0,12), '/'),
@@ -100,6 +125,10 @@ class InstancesController extends Controller
                 'uptime' => $info->getStatus() ?? '',
                 'nodeId' => null,
                 'createdAt' => date('c', $info->getCreated() ?? time()),
+                'ip' => $ip,
+                'ipAddress' => $ip,
+                'scene_instance_id' => $infoExtra->c_scene_instances_id ?? null,
+                'scene_name' => $infoExtra->scene_name ?? null,
             ];
         }
         return response()->json($result);

--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -447,6 +447,7 @@ public function listVmsBySceneInstance(string $instance_id)
     public function getGuacInfo($vmName, Request $request)
     {
         $method = strtolower($request->query('method', 'ssh'));
+        $vmQueryName = $request->query('vm_name', $vmName);
 
         try {
             $xml = $this->runVirsh('dumpxml', $vmName);
@@ -467,16 +468,14 @@ public function listVmsBySceneInstance(string $instance_id)
             }
         } else {
             try {
-                $addrOut = $this->runVirsh('domifaddr', $vmName, '--source', 'agent');
-                $lines = array_slice(preg_split('/\n/', trim($addrOut)), 2);
-                foreach ($lines as $l) {
-                    $parts = preg_split('/\s+/', trim($l));
-                    if (count($parts) >= 4) {
-                        $ip = $parts[3];
-                        break;
-                    }
+                $record = DB::table('c_scene_vm_instances')
+                    ->where('c_vm_name', $vmQueryName)
+                    ->first();
+                if ($record && $record->c_ip) {
+                    $ip = explode('/', $record->c_ip)[0];
                 }
             } catch (\Throwable $e) {
+                Log::error('Failed to fetch VM IP from DB: ' . $e->getMessage());
             }
         }
 

--- a/src/app/scenario/instances/page.tsx
+++ b/src/app/scenario/instances/page.tsx
@@ -85,6 +85,9 @@ const RunningInstancesPage: React.FC = () => {
         cpuUsage: true,
         memoryUsage: true,
         uptime: true,
+        ip: true,
+        sceneId: true,
+        sceneName: true,
     });
     const [fetchError, setFetchError] = useState<string | null>(null);
     const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -130,6 +133,9 @@ const RunningInstancesPage: React.FC = () => {
         { field: 'cpuUsage', headerName: 'CPU', flex: 1, hide: !showColumns.cpuUsage },
         { field: 'memoryUsage', headerName: '内存', flex: 1, hide: !showColumns.memoryUsage },
         { field: 'uptime', headerName: '运行时间', flex: 1, hide: !showColumns.uptime },
+        { field: 'ip', headerName: 'IP', flex: 1, hide: !showColumns.ip },
+        { field: 'scene_instance_id', headerName: '场景实例ID', flex: 1.2, hide: !showColumns.sceneId },
+        { field: 'scene_name', headerName: '场景名称', flex: 1.2, hide: !showColumns.sceneName },
         {
             field: 'actions',
             headerName: '操作',
@@ -355,7 +361,10 @@ const RunningInstancesPage: React.FC = () => {
                                     key === 'ports' ? '端口' :
                                         key === 'cpuUsage' ? 'CPU 使用率' :
                                             key === 'memoryUsage' ? '内存使用率' :
-                                                '运行时间'
+                                                key === 'ip' ? 'IP' :
+                                                    key === 'sceneId' ? '场景实例ID' :
+                                                        key === 'sceneName' ? '场景名称' :
+                                                            '运行时间'
                         } />
                     </MenuItem>
                 ))}

--- a/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
@@ -49,6 +49,9 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         cpuUsage: true,
         memoryUsage: true,
         uptime: true,
+        ip: true,
+        sceneId: true,
+        sceneName: true,
     });
 
     const getStatusChipColor = (status: InstanceStatus): "success" | "warning" | "error" | "info" | "default" => {
@@ -153,6 +156,9 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         { field: 'cpuUsage', headerName: 'CPU', width: 100, hide: !showColumns.cpuUsage },
         { field: 'memoryUsage', headerName: '内存', flex: 1, hide: !showColumns.memoryUsage },
         { field: 'uptime', headerName: '运行时间', flex: 1, hide: !showColumns.uptime },
+        { field: 'ip', headerName: 'IP', flex: 1.2, hide: !showColumns.ip },
+        { field: 'scene_instance_id', headerName: '场景实例ID', flex: 1.2, hide: !showColumns.sceneId },
+        { field: 'scene_name', headerName: '场景名称', flex: 1.2, hide: !showColumns.sceneName },
         { field: 'id', headerName: '容器ID', flex: 1, hide: !showColumns.id, renderCell: (params) => <Tooltip title={params.value}><code>{params.value.substring(0,12)}...</code></Tooltip> },
         {
             field: 'actions', headerName: '操作', sortable: false, width: 180,
@@ -251,6 +257,9 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
                             key === 'ports' ? '端口' :
                             key === 'cpuUsage' ? 'CPU' :
                             key === 'memoryUsage' ? '内存' :
+                            key === 'ip' ? 'IP' :
+                            key === 'sceneId' ? '场景实例ID' :
+                            key === 'sceneName' ? '场景名称' :
                             '运行时间'
                         } />
                     </MenuItem>

--- a/src/app/scenario/sceneinstances/VmInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/VmInstancesTab.tsx
@@ -185,7 +185,7 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
 
     const handleGuac = async (vmName: string, proto: 'ssh' | 'rdp' | 'vnc') => {
         try {
-            const res = await fetch(`/back/api/vms/${vmName}/guac?method=${proto}`);
+            const res = await fetch(`/back/api/vms/${vmName}/guac?method=${proto}&vm_name=${encodeURIComponent(vmName)}`);
             if (!res.ok) throw new Error('Guacamole info request failed');
             const info = await res.json();
             const port = proto === 'ssh' ? info.ssh_port : proto === 'rdp' ? info.rdp_port : info.vnc_port;

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -359,7 +359,7 @@ export default function VmPage() {
 
     const handleGuac = async (vm: VmInstance, proto: 'ssh' | 'rdp' | 'vnc') => {
         try {
-            const res = await fetch(`/back/api/vms/${vm.name}/guac?method=${proto}`);
+            const res = await fetch(`/back/api/vms/${vm.name}/guac?method=${proto}&vm_name=${encodeURIComponent(vm.name)}`);
             if (!res.ok) throw new Error('Guacamole info request failed');
             const info = await res.json();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,9 @@ export interface RunningInstance {
   name: string;
   type: string; // <-- 这里被修改，以支持 '虚拟机', '容器', '交换机' 等多种类型
   ipAddress: string;
+  ip?: string;
+  scene_instance_id?: string;
+  scene_name?: string;
   status: InstanceStatus;
   /** 端口映射，如 "80->8080" */
   ports?: string;


### PR DESCRIPTION
## Summary
- fetch VM IP for Guacamole from database
- pass `vm_name` query parameter when requesting Guacamole info

## Testing
- `vendor/bin/phpunit` *(fails: ErrorException: Trying to access array offset on null)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687df121a2908320a3d35a6e18fa7628