### PR TITLE
Add scene info columns to container instances

### DIFF
--- a/back/app/Http/Controllers/Docker/InstancesController.php
+++ b/back/app/Http/Controllers/Docker/InstancesController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Services\DockerService;
 use App\Models\Docker\Instance;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 
 class InstancesController extends Controller
 {
@@ -33,6 +34,24 @@ class InstancesController extends Controller
         $role = $request->query('role', 'student');
         $userId = $request->query('userId');
         $containers = $this->docker->listContainers();
+
+        // 先收集所有容器 ID，用于后续一次性查询数据库
+        $ids = array_map(fn($c) => $c->getId(), $containers);
+        $extra = [];
+        if ($ids) {
+            try {
+                $extra = DB::table('c_scene_container_instances as ci')
+                    ->leftJoin('c_scene_instances as si', DB::raw('ci.c_scene_instances_id COLLATE utf8mb4_unicode_ci'), '=', 'si.c_scene_instances_id')
+                    ->leftJoin('c_scene_configs as sc', 'si.c_config_id', '=', 'sc.c_config_id')
+                    ->select('ci.c_container_id', 'ci.c_scene_instances_id', 'ci.c_ip', 'sc.c_name as scene_name')
+                    ->whereIn('ci.c_container_id', $ids)
+                    ->get()
+                    ->keyBy('c_container_id');
+            } catch (\Throwable $e) {
+                $extra = [];
+            }
+        }
+
         $result = [];
         foreach ($containers as $info) {
             $labels = $info->getLabels() ?? [];
@@ -87,10 +106,15 @@ class InstancesController extends Controller
                 }
             }
 
+            $infoExtra = $extra[$info->getId()] ?? null;
+
             $result[] = [
                 'id' => $info->getId(),
                 'name' => ltrim($info->getNames()[0] ?? substr($info->getId(),0,12), '/'),
                 'type' => 'container',
+                'ipAddress' => $infoExtra->c_ip ?? null,
+                'scene_instance_id' => $infoExtra->c_scene_instances_id ?? null,
+                'scene_name' => $infoExtra->scene_name ?? null,
                 'status' => $this->mapStatus($info->getState()),
                 'ports' => implode(', ', $ports),
                 'imageName' => $info->getImage(),

--- a/src/app/scenario/instances/page.tsx
+++ b/src/app/scenario/instances/page.tsx
@@ -85,6 +85,9 @@ const RunningInstancesPage: React.FC = () => {
         cpuUsage: true,
         memoryUsage: true,
         uptime: true,
+        ipAddress: true,
+        scene_instance_id: true,
+        scene_name: true,
     });
     const [fetchError, setFetchError] = useState<string | null>(null);
     const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -124,6 +127,9 @@ const RunningInstancesPage: React.FC = () => {
         { field: 'status', headerName: '状态', flex: 1, renderCell: (params) => (
                 <Chip label={STATUS_TRANSLATIONS[params.row.status]} color={getStatusChipColor(params.row.status)} size="small" />
             ) },
+        { field: 'ipAddress', headerName: 'IP', flex: 1, hide: !showColumns.ipAddress },
+        { field: 'scene_instance_id', headerName: '场景实例ID', flex: 1, hide: !showColumns.scene_instance_id },
+        { field: 'scene_name', headerName: '场景名称', flex: 1, hide: !showColumns.scene_name },
         { field: 'id', headerName: '容器ID', flex: 1, hide: !showColumns.id },
         { field: 'imageName', headerName: '镜像名', flex: 1, hide: !showColumns.imageName },
         { field: 'ports', headerName: '端口', flex: 1, hide: !showColumns.ports },
@@ -294,7 +300,8 @@ const RunningInstancesPage: React.FC = () => {
         let processedInstances = [...instances].filter(instance =>
             instance.name.toLowerCase().includes(searchTerm) ||
             instance.id.includes(searchTerm) ||
-            instance.imageName.toLowerCase().includes(searchTerm)
+            instance.imageName.toLowerCase().includes(searchTerm) ||
+            (instance.ipAddress ?? '').includes(searchTerm)
         );
         if (showRunningOnly) {
             processedInstances = processedInstances.filter(i => i.status === 'running');
@@ -349,14 +356,20 @@ const RunningInstancesPage: React.FC = () => {
             <Menu anchorEl={columnAnchorEl} open={Boolean(columnAnchorEl)} onClose={()=>setColumnAnchorEl(null)}>
                 {Object.entries(showColumns).map(([key,val])=> (
                     <MenuItem key={key}>
-                        <FormControlLabel control={<Switch checked={val} onChange={(e)=>setShowColumns(prev=>({...prev,[key]:e.target.checked}))} color="primary"/>} label={
-                            key === 'id' ? '容器 ID' :
+                        <FormControlLabel
+                            control={<Switch checked={val} onChange={(e)=>setShowColumns(prev=>({...prev,[key]:e.target.checked}))} color="primary"/>}
+                            label={
+                                key === 'id' ? '容器 ID' :
                                 key === 'imageName' ? '镜像名' :
-                                    key === 'ports' ? '端口' :
-                                        key === 'cpuUsage' ? 'CPU 使用率' :
-                                            key === 'memoryUsage' ? '内存使用率' :
-                                                '运行时间'
-                        } />
+                                key === 'ports' ? '端口' :
+                                key === 'cpuUsage' ? 'CPU 使用率' :
+                                key === 'memoryUsage' ? '内存使用率' :
+                                key === 'ipAddress' ? 'IP' :
+                                key === 'scene_instance_id' ? '场景实例ID' :
+                                key === 'scene_name' ? '场景名称' :
+                                '运行时间'
+                            }
+                        />
                     </MenuItem>
                 ))}
             </Menu>

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,7 +163,12 @@ export interface RunningInstance {
   id: string;
   name: string;
   type: string; // <-- 这里被修改，以支持 '虚拟机', '容器', '交换机' 等多种类型
-  ipAddress: string;
+  /** 实例的 IP 地址 */
+  ipAddress?: string;
+  /** 关联的场景实例 ID */
+  scene_instance_id?: string;
+  /** 关联场景的名称 */
+  scene_name?: string;
   status: InstanceStatus;
   /** 端口映射，如 "80->8080" */
   ports?: string;


### PR DESCRIPTION
## Summary
- extend RunningInstance model with optional IP and scene info
- include container IP and scene details from database in InstancesController
- show IP, scene ID and scene name columns in container instances page

## Testing
- `npm run build`
- `composer install --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_687e2b4bac948320b2deedaa83814ffa