### PR TITLE
Add API for retrieving single Docker container info

### DIFF
--- a/back/app/Http/Controllers/Docker/ContainersController.php
+++ b/back/app/Http/Controllers/Docker/ContainersController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Docker;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Services\DockerService;
+use Illuminate\Support\Facades\DB;
 
 class ContainersController extends Controller
 {
@@ -13,6 +14,17 @@ class ContainersController extends Controller
     public function __construct(DockerService $docker)
     {
         $this->docker = $docker;
+    }
+
+    private function mapStatus(?string $state): string
+    {
+        return match ($state) {
+            'running' => 'running',
+            'paused' => 'paused',
+            'created', 'exited', 'dead' => 'stopped',
+            'restarting' => 'starting',
+            default => 'error',
+        };
     }
 
     public function create(Request $request)
@@ -58,5 +70,68 @@ class ContainersController extends Controller
         $data = json_decode($raw, true);                  // 可选：转数组// 对象
         logger()->info('Container info', $data);
         return response()->json($data);
+    }
+
+    public function info(string $id)
+    {
+        try {
+            $detail = $this->docker->containerInspect($id);
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'container not found'], 404);
+        }
+
+        try {
+            $stats = $this->docker->containerStats($detail->getId());
+            $cpuDelta = ($stats->cpu_stats->cpu_usage->total_usage ?? 0) - ($stats->precpu_stats->cpu_usage->total_usage ?? 0);
+            $sysDelta = ($stats->cpu_stats->system_cpu_usage ?? 0) - ($stats->precpu_stats->system_cpu_usage ?? 0);
+            $cpus = $stats->cpu_stats->online_cpus ?? (is_array($stats->cpu_stats->cpu_usage->percpu_usage ?? null) ? count($stats->cpu_stats->cpu_usage->percpu_usage) : 1);
+            $cpuPercent = $sysDelta > 0 ? ($cpuDelta / $sysDelta) * $cpus * 100 : 0;
+            $memUsage = $stats->memory_stats->usage ?? 0;
+            $memLimit = $stats->memory_stats->limit ?? 0;
+        } catch (\Exception $e) {
+            $cpuPercent = 0;
+            $memUsage = 0;
+            $memLimit = 0;
+        }
+
+        $ports = [];
+        $bindings = $detail->getHostConfig()->getPortBindings();
+        foreach ($bindings ?? [] as $portKey => $bindingList) {
+            foreach ($bindingList ?? [] as $b) {
+                $hostPort = $b->getHostPort();
+                $private = strtok($portKey, '/');
+                $ports[] = "{$hostPort}:{$private}";
+            }
+        }
+
+        $infoExtra = null;
+        try {
+            $infoExtra = DB::table('c_scene_container_instances as ci')
+                ->leftJoin('c_scene_instances as si', DB::raw('ci.c_scene_instances_id COLLATE utf8mb4_unicode_ci'), '=', 'si.c_scene_instances_id')
+                ->leftJoin('c_scene_configs as sc', 'si.c_config_id', '=', 'sc.c_config_id')
+                ->select('ci.c_container_id', 'ci.c_scene_instances_id', 'ci.c_ip', 'sc.c_name as scene_name')
+                ->where('ci.c_container_id', $detail->getId())
+                ->first();
+        } catch (\Throwable $e) {
+            $infoExtra = null;
+        }
+
+        return response()->json([
+            'id' => $detail->getId(),
+            'name' => ltrim($detail->getName() ?? substr($detail->getId(), 0, 12), '/'),
+            'type' => 'container',
+            'ipAddress' => $infoExtra->c_ip ?? ($detail->getNetworkSettings()->getIPAddress() ?? null),
+            'scene_instance_id' => $infoExtra->c_scene_instances_id ?? null,
+            'scene_name' => $infoExtra->scene_name ?? null,
+            'status' => $this->mapStatus($detail->getState()?->getStatus()),
+            'ports' => implode(', ', $ports),
+            'imageName' => $detail->getConfig()->getImage(),
+            'cpuUsage' => sprintf('%.1f%%', $cpuPercent),
+            'memoryUsage' => sprintf('%.1fMB/%.1fMB', $memUsage/1024/1024, $memLimit/1024/1024),
+            'diskUsage' => '-',
+            'uptime' => $detail->getState()?->getStatus() ?? '',
+            'nodeId' => null,
+            'createdAt' => date('c', $detail->getCreated() ? strtotime($detail->getCreated()) : time()),
+        ]);
     }
 }

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -216,6 +216,7 @@ Route::prefix('containers')->group(function () {
     Route::get('/{id}/logs', [ContainersController::class, 'logs']);
     Route::get('/{id}/inspect', [ContainersController::class, 'inspect']);
     Route::get('/{id}/binds', [ContainersController::class, 'binds']);
+    Route::get('/{id}/info', [ContainersController::class, 'info']);
 });
 
 


### PR DESCRIPTION
## Summary
- expose /containers/{id}/info endpoint to return detailed container metrics
- compute CPU/memory usage and port mappings using Docker stats/inspect

## Testing
- `cd back && ./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68905908444083208c68699694527c19