### PR TITLE
feat: mark target instances in VM and container APIs

### DIFF
--- a/back/app/Http/Controllers/Docker/ContainersController.php
+++ b/back/app/Http/Controllers/Docker/ContainersController.php
@@ -109,7 +109,7 @@ class ContainersController extends Controller
             $infoExtra = DB::table('c_scene_container_instances as ci')
                 ->leftJoin('c_scene_instances as si', DB::raw('ci.c_scene_instances_id COLLATE utf8mb4_unicode_ci'), '=', 'si.c_scene_instances_id')
                 ->leftJoin('c_scene_configs as sc', 'si.c_config_id', '=', 'sc.c_config_id')
-                ->select('ci.c_container_id', 'ci.c_scene_instances_id', 'ci.c_ip', 'sc.c_name as scene_name')
+                ->select('ci.c_container_id', 'ci.c_scene_instances_id', 'ci.c_ip', 'ci.c_flag', 'sc.c_name as scene_name')
                 ->where('ci.c_container_id', $detail->getId())
                 ->first();
         } catch (\Throwable $e) {
@@ -123,6 +123,7 @@ class ContainersController extends Controller
             'ipAddress' => $infoExtra->c_ip ?? ($detail->getNetworkSettings()->getIPAddress() ?? null),
             'scene_instance_id' => $infoExtra->c_scene_instances_id ?? null,
             'scene_name' => $infoExtra->scene_name ?? null,
+            'is_target' => !empty($infoExtra->c_flag ?? null),
             'status' => $this->mapStatus($detail->getState()?->getStatus()),
             'ports' => implode(', ', $ports),
             'imageName' => $detail->getConfig()->getImage(),

--- a/back/app/Http/Controllers/Docker/InstancesController.php
+++ b/back/app/Http/Controllers/Docker/InstancesController.php
@@ -43,7 +43,7 @@ class InstancesController extends Controller
                 $extra = DB::table('c_scene_container_instances as ci')
                     ->leftJoin('c_scene_instances as si', DB::raw('ci.c_scene_instances_id COLLATE utf8mb4_unicode_ci'), '=', 'si.c_scene_instances_id')
                     ->leftJoin('c_scene_configs as sc', 'si.c_config_id', '=', 'sc.c_config_id')
-                    ->select('ci.c_container_id', 'ci.c_scene_instances_id', 'ci.c_ip', 'sc.c_name as scene_name')
+                    ->select('ci.c_container_id', 'ci.c_scene_instances_id', 'ci.c_ip', 'ci.c_flag', 'sc.c_name as scene_name')
                     ->whereIn('ci.c_container_id', $ids)
                     ->get()
                     ->keyBy('c_container_id');
@@ -115,6 +115,7 @@ class InstancesController extends Controller
                 'ipAddress' => $infoExtra->c_ip ?? null,
                 'scene_instance_id' => $infoExtra->c_scene_instances_id ?? null,
                 'scene_name' => $infoExtra->scene_name ?? null,
+                'is_target' => !empty($infoExtra->c_flag ?? null),
                 'status' => $this->mapStatus($info->getState()),
                 'ports' => implode(', ', $ports),
                 'imageName' => $info->getImage(),

--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -304,6 +304,7 @@ public function listVmsBySceneInstance(string $instance_id)
                         'v.c_vm_name',
                         'v.c_scene_instances_id',
                         'v.c_ip',
+                        'v.c_flag',
                         'sc.c_name as scene_name'
                     )
                     ->whereIn('v.c_vm_name', $names)
@@ -319,6 +320,7 @@ public function listVmsBySceneInstance(string $instance_id)
                 $vm['scene_instance_id'] = $info->c_scene_instances_id ?? null;
                 $vm['scene_name'] = $info->scene_name ?? null;
                 $vm['ip'] = $info->c_ip ?? null;
+                $vm['is_target'] = !empty($info->c_flag ?? null);
             }
         }
 
@@ -516,6 +518,15 @@ public function listVmsBySceneInstance(string $instance_id)
         } catch (\Throwable $e) {
         }
 
+        $flag = null;
+        try {
+            $flag = DB::table('c_scene_vm_instances')
+                ->where('c_vm_name', $vmId)
+                ->value('c_flag');
+        } catch (\Throwable $e) {
+            $flag = null;
+        }
+
         return response()->json([
             'status' => $state,
             'hostNode' => $host,
@@ -528,6 +539,7 @@ public function listVmsBySceneInstance(string $instance_id)
             'autostart' => $autostart,
             'uuid' => $vmId,
             'ipAddress' => $ip,
+            'is_target' => !empty($flag),
         ], 200);
     }
 


### PR DESCRIPTION
## Summary
- return `is_target` from container list/info endpoints
- include `is_target` from VM list and detail endpoints

## Testing
- `composer update workerman/workerman --no-interaction --no-progress --prefer-dist`
- `./vendor/bin/phpunit` *(fails: Trying to access array offset on null)*

------
https://chatgpt.com/codex/tasks/task_e_689827d82008832095063a991234e5ca