### PR TITLE
feat: improve image selection and listing

### DIFF
--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -244,39 +244,42 @@ public function listVmsBySceneInstance(string $instance_id)
     {
         $images = [];
         try {
+            $poolXml = $this->runVirsh('pool-dumpxml', 'default');
+        } catch (\RuntimeException $e) {
+            return $images;
+        }
+        $poolRoot = new \SimpleXMLElement($poolXml);
+        $poolPath = (string)($poolRoot->xpath('.//target/path')[0] ?? '');
+
+        try {
             $output = $this->runVirsh('vol-list', 'default');
         } catch (\RuntimeException $e) {
             return $images;
         }
+
         $lines = array_slice(preg_split('/\n/', trim($output)), 2);
         foreach ($lines as $line) {
             if (!trim($line)) { continue; }
             $parts = preg_split('/\s+/', trim($line));
-            if (count($parts) < 2) { continue; }
+            if (count($parts) < 1) { continue; }
             $vol = $parts[0];
-            $path = $parts[1];
+            $path = $parts[1] ?? rtrim($poolPath, '/') . '/' . $vol;
             try {
-                $infoOut = $this->runVirsh('vol-info', $vol, '--pool', 'default');
+                $lsOut = $this->runCommand(['ls', '-l', '--time-style=long-iso', $path]);
             } catch (\RuntimeException $e) {
                 continue;
             }
-            $sizeMb = 0.0;
-            foreach (preg_split('/\n/', trim($infoOut)) as $l) {
-                if (str_starts_with($l, 'Capacity:')) {
-                    $infoParts = preg_split('/\s+/', $l);
-                    if (count($infoParts) >= 3) {
-                        $sizeMb = $this->sizeToMb((float)$infoParts[1], $infoParts[2]);
-                    }
-                    break;
-                }
-            }
-            $mtime = @filemtime($path);
-            $uploadDate = $mtime ? date('c', $mtime) : null;
+            $lsParts = preg_split('/\s+/', trim($lsOut), 9);
+            $bytes = (int)($lsParts[4] ?? 0);
+            $date = $lsParts[5] ?? '';
+            $time = $lsParts[6] ?? '';
+            $uploadDate = ($date && $time) ? date('c', strtotime("$date $time")) : null;
+
             $images[] = [
                 'id' => $vol,
                 'name' => $vol,
                 'pool' => 'default',
-                'size' => sprintf('%.1f MB', $sizeMb),
+                'size' => sprintf('%.1f MB', $bytes / 1024 / 1024),
                 'path' => $path,
                 'modifiedDate' => $uploadDate,
                 'status' => 'available',

--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -265,12 +265,12 @@ public function listVmsBySceneInstance(string $instance_id)
             $vol = $parts[0];
             $path = $parts[1] ?? rtrim($poolPath, '/') . '/' . $vol;
             try {
-                $lsOut = $this->runCommand(['ls', '-l', '--time-style=long-iso', $path]);
+                $lsOut = $this->runCommand(['ls', '-l', '--time-style=long-iso', '--block-size=1M', $path]);
             } catch (\RuntimeException $e) {
                 continue;
             }
             $lsParts = preg_split('/\s+/', trim($lsOut), 9);
-            $bytes = (int)($lsParts[4] ?? 0);
+            $sizeMb = $lsParts[4] ?? '0M';
             $date = $lsParts[5] ?? '';
             $time = $lsParts[6] ?? '';
             $uploadDate = ($date && $time) ? date('c', strtotime("$date $time")) : null;
@@ -279,10 +279,42 @@ public function listVmsBySceneInstance(string $instance_id)
                 'id' => $vol,
                 'name' => $vol,
                 'pool' => 'default',
-                'size' => sprintf('%.1f MB', $bytes / 1024 / 1024),
+                'size' => $sizeMb,
                 'path' => $path,
                 'modifiedDate' => $uploadDate,
                 'status' => 'available',
+            ];
+        }
+        return $images;
+    }
+
+    private function fetchVmImagePaths(): array
+    {
+        $images = [];
+        try {
+            $poolXml = $this->runVirsh('pool-dumpxml', 'default');
+        } catch (\RuntimeException $e) {
+            return $images;
+        }
+        $poolRoot = new \SimpleXMLElement($poolXml);
+        $poolPath = (string)($poolRoot->xpath('.//target/path')[0] ?? '');
+
+        try {
+            $output = $this->runVirsh('vol-list', 'default');
+        } catch (\RuntimeException $e) {
+            return $images;
+        }
+
+        $lines = array_slice(preg_split('/\n/', trim($output)), 2);
+        foreach ($lines as $line) {
+            if (!trim($line)) { continue; }
+            $parts = preg_split('/\s+/', trim($line));
+            if (count($parts) < 1) { continue; }
+            $vol = $parts[0];
+            $path = $parts[1] ?? rtrim($poolPath, '/') . '/' . $vol;
+            $images[] = [
+                'name' => $vol,
+                'path' => $path,
             ];
         }
         return $images;
@@ -344,6 +376,17 @@ public function listVmsBySceneInstance(string $instance_id)
             unset($img['version'], $img['osType'], $img['architecture']);
         }
 
+        return response()->json($data, 200);
+    }
+
+    // GET /vms/image-options
+    public function listVmImageOptions()
+    {
+        try {
+            $data = $this->fetchVmImagePaths();
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 500);
+        }
         return response()->json($data, 200);
     }
 

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -208,6 +208,7 @@ Route::prefix('vms')->group(function () {
     $c = \App\Http\Controllers\Vm\VmController::class;
     Route::get('/', [$c, 'listVms']);
     Route::get('/images', [$c, 'listVmImages']);
+    Route::get('/image-options', [$c, 'listVmImageOptions']);
     Route::post('/create', [$c, 'createVm']);
     Route::get('/{vm_name}/guac', [$c, 'getGuacInfo']);
     Route::get('/{vm_id}', [$c, 'getVmInfo']);

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -183,7 +183,7 @@ const [selectedFile, setSelectedFile] = useState<File | null>(null)
             minWidth: 160,
             // Align with container pages: parse ISO string and format as locale date
             valueFormatter: (params) => {
-                return dayjs(params).format('YYYY年M月D日');
+                return dayjs(params.value as string).format('YYYY年M月D日 HH:mm:ss');
             }
         },
         {

--- a/src/components/scenario/CreateContainerModal.tsx
+++ b/src/components/scenario/CreateContainerModal.tsx
@@ -10,12 +10,9 @@ import {
   IconButton,
   Box,
   Stack,
-  MenuItem,
-  InputLabel,
-  FormControl,
-  Select,
   Typography
 } from '@mui/material';
+import Autocomplete from '@mui/material/Autocomplete';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import { ManagedImage } from '@/types';
@@ -115,19 +112,15 @@ export default function CreateContainerModal({ open, onClose, onCreated, fixedIm
           {fixedImage ? (
             <TextField label="镜像" value={image} fullWidth disabled />
           ) : (
-            <FormControl fullWidth>
-              <InputLabel id="image-select-label">镜像</InputLabel>
-              <Select
-                labelId="image-select-label"
-                value={image}
-                label="镜像"
-                onChange={e => setImage(e.target.value)}
-              >
-                {images.map(img => (
-                  <MenuItem key={img.id} value={`${img.name}:${img.version}`}>{`${img.name}:${img.version}`}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <Autocomplete
+              freeSolo
+              options={images.map(img => `${img.name}:${img.version}`)}
+              value={image}
+              inputValue={image}
+              onInputChange={(_, val) => setImage(val)}
+              onChange={(_, val) => setImage(val || '')}
+              renderInput={(params) => <TextField {...params} label="镜像" />}
+            />
           )}
           <TextField label="容器名称" value={name} onChange={e => setName(e.target.value)} fullWidth />
           <Box>

--- a/src/components/vm/CreateVmModal.tsx
+++ b/src/components/vm/CreateVmModal.tsx
@@ -8,13 +8,10 @@ import {
   Button,
   TextField,
   Stack,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
   FormControlLabel,
   Checkbox
 } from "@mui/material";
+import Autocomplete from '@mui/material/Autocomplete';
 
 interface VmImage {
   id: string;
@@ -83,19 +80,15 @@ export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: 
           {fixedImage ? (
             <TextField label="镜像" value={form.image} fullWidth disabled />
           ) : (
-            <FormControl fullWidth>
-              <InputLabel id="img-label">镜像</InputLabel>
-              <Select
-                labelId="img-label"
-                value={form.image}
-                label="镜像"
-                onChange={e => setForm(f => ({ ...f, image: e.target.value }))}
-              >
-                {images.map(img => (
-                  <MenuItem key={img.id} value={img.name}>{img.name}</MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <Autocomplete
+              freeSolo
+              options={images.map(img => img.name)}
+              value={form.image}
+              inputValue={form.image}
+              onInputChange={(_, val) => setForm(f => ({ ...f, image: val }))}
+              onChange={(_, val) => setForm(f => ({ ...f, image: val || '' }))}
+              renderInput={(params) => <TextField {...params} label="镜像" />}
+            />
           )}
           <TextField label="实例名称" value={form.vm_name}
             onChange={e => setForm(f => ({ ...f, vm_name: e.target.value }))} fullWidth />

--- a/src/components/vm/CreateVmModal.tsx
+++ b/src/components/vm/CreateVmModal.tsx
@@ -14,7 +14,6 @@ import {
 import Autocomplete from '@mui/material/Autocomplete';
 
 interface VmImage {
-  id: string;
   name: string;
   path: string;
 }
@@ -42,7 +41,7 @@ export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: 
       setForm(f => ({ ...f, image: name }));
       setImages([]);
     } else {
-      fetch("/back/api/vms/images")
+      fetch("/back/api/vms/image-options")
         .then(res => res.json())
         .then(data => setImages(data));
     }


### PR DESCRIPTION
## Summary
- allow typing or searching when selecting images for containers and VMs
- derive VM image size and timestamp via ls for faster fetch
- show image modified time with hour/minute/second

## Testing
- `./vendor/bin/phpunit` (fails: Trying to access array offset on null)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a570f239808320ba91a05afd1ed4c8