### PR TITLE
Add image import/export and expand VM image categories

### DIFF
--- a/back/app/Http/Controllers/Docker/ImagesController.php
+++ b/back/app/Http/Controllers/Docker/ImagesController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Services\DockerService;
 use App\Models\Docker\Image;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ImagesController extends Controller
 {
@@ -73,5 +74,35 @@ class ImagesController extends Controller
             Image::where('id', $id)->delete();
         }
         return response()->json(['ok' => true]);
+    }
+
+    public function import(Request $request)
+    {
+        $file = $request->file('file');
+        if (!$file) {
+            return response()->json(['error' => 'no file'], 400);
+        }
+        $stream = fopen($file->getRealPath(), 'r');
+        $this->docker->importImage($stream);
+        fclose($stream);
+        return response()->json(['ok' => true]);
+    }
+
+    public function export(Request $request)
+    {
+        $id = $request->query('id');
+        if (!$id) {
+            return response()->json(['error' => 'missing id'], 400);
+        }
+        $name = $request->query('name', $id);
+        $stream = $this->docker->exportImage($id);
+        return new StreamedResponse(function () use ($stream) {
+            while (!$stream->eof()) {
+                echo $stream->read(1024);
+            }
+        }, 200, [
+            'Content-Type' => 'application/x-tar',
+            'Content-Disposition' => 'attachment; filename="' . $name . '.tar"',
+        ]);
     }
 }

--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -488,6 +488,52 @@ public function listVmsBySceneInstance(string $instance_id)
         return response()->json($data, 200);
     }
 
+    // POST /vms/images/import
+    public function importVmImage(Request $request)
+    {
+        $file = $request->file('file');
+        if (!$file) {
+            return response()->json(['error' => 'no file'], 400);
+        }
+        try {
+            $poolXml = $this->runVirsh('pool-dumpxml', 'default');
+            $poolRoot = new \SimpleXMLElement($poolXml);
+            $poolPath = (string)($poolRoot->xpath('.//target/path')[0] ?? '');
+            if (!$poolPath) {
+                return response()->json(['error' => 'pool path not found'], 500);
+            }
+            $name = $file->getClientOriginalName();
+            $file->move($poolPath, $name);
+        } catch (\Throwable $e) {
+            return response()->json(['error' => 'import failed'], 500);
+        }
+        return response()->json(['ok' => true]);
+    }
+
+    // GET /vms/images/export
+    public function exportVmImage(Request $request)
+    {
+        $name = $request->query('name');
+        if (!$name) {
+            return response()->json(['error' => 'missing name'], 400);
+        }
+        try {
+            $poolXml = $this->runVirsh('pool-dumpxml', 'default');
+            $poolRoot = new \SimpleXMLElement($poolXml);
+            $poolPath = (string)($poolRoot->xpath('.//target/path')[0] ?? '');
+            if (!$poolPath) {
+                return response()->json(['error' => 'pool path not found'], 500);
+            }
+            $filePath = rtrim($poolPath, '/') . '/' . $name;
+            if (!is_file($filePath)) {
+                return response()->json(['error' => 'file not found'], 404);
+            }
+        } catch (\Throwable $e) {
+            return response()->json(['error' => 'export failed'], 500);
+        }
+        return response()->download($filePath, $name);
+    }
+
     // POST /vms/create
     public function createVm(Request $request)
     {

--- a/back/app/Services/DockerService.php
+++ b/back/app/Services/DockerService.php
@@ -11,6 +11,7 @@ use Docker\API\Model\ContainerConfigExposedPortsItem;
 use App\Models\Docker\DockerInstanceModel;
 use App\Models\scenario\SceneContainerInstance;
 use Illuminate\Support\Facades\Log;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -154,6 +155,16 @@ class DockerService
     public function removeImage(string $id)
     {
         $this->docker->imageDelete($id, ['force' => true]);
+    }
+
+    public function importImage($stream): void
+    {
+        $this->docker->imageLoad($stream, ['quiet' => false]);
+    }
+
+    public function exportImage(string $id): StreamInterface
+    {
+        return $this->docker->imageGet($id);
     }
 
     public function containerStats(string $id)

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -187,6 +187,8 @@ Route::prefix('images')->group(function () {
     Route::post('/', [ImagesController::class, 'store']);
     Route::put('/', [ImagesController::class, 'update']);
     Route::delete('/', [ImagesController::class, 'destroy']);
+    Route::post('/import', [ImagesController::class, 'import']);
+    Route::get('/export', [ImagesController::class, 'export']);
 });
 
 Route::prefix('instances')->group(function () {
@@ -212,6 +214,8 @@ Route::prefix('vms')->group(function () {
     $c = \App\Http\Controllers\Vm\VmController::class;
     Route::get('/', [$c, 'listVms']);
     Route::get('/images', [$c, 'listVmImages']);
+    Route::post('/images/import', [$c, 'importVmImage']);
+    Route::get('/images/export', [$c, 'exportVmImage']);
     Route::get('/image-options', [$c, 'listVmImageOptions']);
     Route::post('/create', [$c, 'createVm']);
     Route::get('/{vm_name}/guac', [$c, 'getGuacInfo']);

--- a/src/app/scenario/images/page.tsx
+++ b/src/app/scenario/images/page.tsx
@@ -30,6 +30,8 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import SearchIcon from '@mui/icons-material/Search';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { ManagedImage } from '@/types';
 import ImageFormModal from '@/components/imagemanagement/ImageFormModal';
 import CreateContainerModal from '@/components/scenario/CreateContainerModal';
@@ -120,6 +122,29 @@ const ImageManagementPage: React.FC = () => {
     setCreateModalImage(`${image.name}:${image.version}`);
   };
 
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    await fetch(`${API_BASE}/images/import`, { method: 'POST', body: form });
+    e.target.value = '';
+    fetchImages();
+  };
+
+  const handleExport = async (image: ManagedImage) => {
+    const res = await fetch(`${API_BASE}/images/export?id=${image.id}`);
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${image.name}-${image.version}.tar`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+  };
+
   const handleRefresh = () => {
     setIsLoading(true);
     fetchImages().finally(() => setIsLoading(false));
@@ -156,16 +181,21 @@ const ImageManagementPage: React.FC = () => {
               width: '90%',
               height: '100%',             // 撑满单元格
             }}>
-              <Tooltip title="启动">
-                <IconButton onClick={() => handleStart(image)} size="small">
-                  <PlayArrowIcon fontSize="small" color="success" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="删除镜像">
-                <IconButton onClick={() => handleOpenConfirmDialog(image)} color="error" size="small">
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
+          <Tooltip title="启动">
+            <IconButton onClick={() => handleStart(image)} size="small">
+              <PlayArrowIcon fontSize="small" color="success" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="导出镜像">
+            <IconButton onClick={() => handleExport(image)} size="small">
+              <FileDownloadIcon fontSize="small" color="primary" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="删除镜像">
+            <IconButton onClick={() => handleOpenConfirmDialog(image)} color="error" size="small">
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
             </Box>
         );
       }
@@ -200,6 +230,15 @@ const ImageManagementPage: React.FC = () => {
             <Button startIcon={<ViewColumnIcon />} onClick={(e)=>setColumnAnchorEl(e.currentTarget)} variant="outlined" size="small">显示列</Button>
           </Box>
           <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+                variant="contained"
+                component="label"
+                startIcon={<CloudUploadIcon />}
+                size="small"
+            >
+              导入
+              <input type="file" hidden onChange={handleImport} />
+            </Button>
             <Button
                 variant="outlined"
                 startIcon={isLoading ? <CircularProgress size={20} color="inherit" /> : <RefreshIcon />}

--- a/src/app/scenario/vm-images/page.tsx
+++ b/src/app/scenario/vm-images/page.tsx
@@ -20,12 +20,16 @@ import {
     Button,
     Tooltip,
     useTheme,
+    CircularProgress,
 } from "@mui/material"
 import {
     Edit as EditIcon,
     Delete as DeleteIcon,
     PlayArrow as StartIcon,
     Search as SearchIcon,
+    CloudUpload as CloudUploadIcon,
+    FileDownload as FileDownloadIcon,
+    Refresh as RefreshIcon,
 } from "@mui/icons-material"
 import { DataGrid, GridColDef } from "@mui/x-data-grid"
 import dayjs from "dayjs"
@@ -35,7 +39,7 @@ import { customFetch } from "@/utils/fetch"
 interface VmImage {
     id: string
     name: string
-    osType?: "Windows" | "Linux" | "Other"
+    osType?: string
     size: string
     description?: string
     modifiedDate?: string
@@ -44,21 +48,25 @@ interface VmImage {
 
 const VmImageManagementPage: React.FC = () => {
     const [images, setImages] = useState<VmImage[]>([])
-    const [overrides, setOverrides] = useState<Record<string, { osType?: VmImage["osType"]; description?: string }>>({})
+    const [overrides, setOverrides] = useState<Record<string, { osType?: string; description?: string }>>({})
     const [openDialog, setOpenDialog] = useState(false)
     const [editingImage, setEditingImage] = useState<VmImage | null>(null)
     const [createModalImage, setCreateModalImage] = useState<string | null>(null)
     const [formData, setFormData] = useState<{
         name: string
-        osType: VmImage["osType"] | ""
+        osType: string
         description: string
     }>({
         name: "",
         osType: "",
         description: "",
     })
+    const [osTypeOption, setOsTypeOption] = useState<string>("")
+    const [customOsType, setCustomOsType] = useState("")
+    const osOptions = ["ubuntu", "win7", "win10", "win7sp1", "win2003"]
+    const [isLoading, setIsLoading] = useState(false)
 
-    useEffect(() => {
+    const fetchImages = () =>
         Promise.all([
             customFetch('/back/api/vms/images').then(res => res.json()).catch(() => []),
             fetch('/api/vm-image-overrides').then(res => res.json()).catch(() => ({})),
@@ -70,13 +78,22 @@ const VmImageManagementPage: React.FC = () => {
             })
             setImages(merged)
         })
-    }, [])
+
+    useEffect(() => { fetchImages() }, [])
 
     const handleOpenDialog = (image: VmImage) => {
         setEditingImage(image)
+        const os = image.osType || ""
+        if (osOptions.includes(os)) {
+            setOsTypeOption(os)
+            setCustomOsType("")
+        } else {
+            setOsTypeOption("custom")
+            setCustomOsType(os)
+        }
         setFormData({
             name: image.name,
-            osType: image.osType ?? "",
+            osType: os,
             description: image.description || '',
         })
         setOpenDialog(true)
@@ -89,6 +106,34 @@ const VmImageManagementPage: React.FC = () => {
 
     const handleStart = (image: VmImage) => {
         setCreateModalImage(image.name)
+    }
+
+    const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (!file) return
+        const form = new FormData()
+        form.append('file', file)
+        await fetch('/back/api/vms/images/import', { method: 'POST', body: form })
+        e.target.value = ''
+        fetchImages()
+    }
+
+    const handleExport = async (image: VmImage) => {
+        const res = await fetch(`/back/api/vms/images/export?name=${encodeURIComponent(image.name)}`)
+        const blob = await res.blob()
+        const url = window.URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = image.name
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+        window.URL.revokeObjectURL(url)
+    }
+
+    const handleRefresh = () => {
+        setIsLoading(true)
+        fetchImages().finally(() => setIsLoading(false))
     }
 
     const handleSave = async () => {
@@ -203,12 +248,17 @@ const VmImageManagementPage: React.FC = () => {
             field: 'actions',
             headerName: '操作',
             sortable: false,
-            width: 140,
+            width: 180,
             renderCell: params => (
                 <Box>
                     <Tooltip title="启动">
                         <IconButton size="small" onClick={() => handleStart(params.row)}>
                             <StartIcon color="success" />
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="导出">
+                        <IconButton size="small" onClick={() => handleExport(params.row)}>
+                            <FileDownloadIcon color="primary" />
                         </IconButton>
                     </Tooltip>
                     <Tooltip title="编辑">
@@ -244,6 +294,25 @@ const VmImageManagementPage: React.FC = () => {
                         sx={{ width: { xs: '100%', sm: 260 } }}
                     />
                 </Box>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                    <Button
+                        variant="contained"
+                        component="label"
+                        startIcon={<CloudUploadIcon />}
+                        size="small"
+                    >
+                        导入
+                        <input type="file" hidden onChange={handleImport} />
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        startIcon={isLoading ? <CircularProgress size={20} color="inherit" /> : <RefreshIcon />}
+                        onClick={handleRefresh}
+                        disabled={isLoading}
+                    >
+                        刷新
+                    </Button>
+                </Box>
             </Box>
 
             <Box component={Paper} sx={{ boxShadow: 3 }}>
@@ -272,23 +341,35 @@ const VmImageManagementPage: React.FC = () => {
                         <FormControl fullWidth>
                             <InputLabel>操作系统类型</InputLabel>
                             <Select
-                                value={formData.osType}
+                                value={osTypeOption}
                                 label="操作系统类型"
-                                onChange={(e) =>
-                                    setFormData((prev) => ({
-                                        ...prev,
-                                        osType: e.target.value as VmImage["osType"] | "",
-                                    }))
-                                }
+                                onChange={(e) => {
+                                    const value = e.target.value as string
+                                    setOsTypeOption(value)
+                                    if (value !== 'custom') {
+                                        setFormData(prev => ({ ...prev, osType: value }))
+                                    } else {
+                                        setFormData(prev => ({ ...prev, osType: customOsType }))
+                                    }
+                                }}
                             >
-                                <MenuItem value="">
-                                    <em>未指定</em>
-                                </MenuItem>
-                                <MenuItem value="Linux">Linux</MenuItem>
-                                <MenuItem value="Windows">Windows</MenuItem>
-                                <MenuItem value="Other">其他</MenuItem>
+                                {osOptions.map(opt => (
+                                    <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+                                ))}
+                                <MenuItem value="custom">自定义</MenuItem>
                             </Select>
                         </FormControl>
+                        {osTypeOption === 'custom' && (
+                            <TextField
+                                label="自定义类别"
+                                value={customOsType}
+                                onChange={(e) => {
+                                    setCustomOsType(e.target.value)
+                                    setFormData(prev => ({ ...prev, osType: e.target.value }))
+                                }}
+                                fullWidth
+                            />
+                        )}
                         <TextField
                             label="描述"
                             value={formData.description}


### PR DESCRIPTION
## Summary
- add container image import/export UI and backend endpoints
- allow VM image category selection for Ubuntu and Windows variants with custom entry
- implement VM image import/export via default storage pool with corresponding UI controls

## Testing
- `npm run build` *(fails: package.json missing)*
- `cd back && php artisan test` *(fails: Failed opening required '/workspace/nads-mine/back/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b25254d46c8320b781079cd0e42af7