### PR TITLE
feat: add snapshot management modal for VMs

### DIFF
--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -200,6 +200,18 @@ public function listVmsBySceneInstance(string $instance_id)
         return false;
     }
 
+    private function calculateSnapshotSize(\SimpleXMLElement $tree): float
+    {
+        $total = 0.0;
+        foreach ($tree->xpath('.//disks/disk/source') as $src) {
+            $file = (string)($src['file'] ?? '');
+            if ($file && is_file($file)) {
+                $total += filesize($file);
+            }
+        }
+        return $total > 0 ? round($total / (1024 * 1024), 2) : 0.0;
+    }
+
     private function fetchVmInstances(): array
     {
         $host = trim($this->runCommand(['hostname']));
@@ -739,11 +751,13 @@ public function listVmsBySceneInstance(string $instance_id)
                 $created = $ctime ? date('c', (int)$ctime) : date('c');
                 $desc = (string)($tree->description ?? '');
                 $parent = (string)($tree->parent->name ?? '');
+                $sizeMb = $this->calculateSnapshotSize($tree);
             } catch (\Throwable $e) {
                 $created = date('c');
                 $xml = '';
                 $desc = '';
                 $parent = '';
+                $sizeMb = 0;
             }
             $snaps[] = [
                 'id' => $name,
@@ -751,7 +765,7 @@ public function listVmsBySceneInstance(string $instance_id)
                 'description' => $desc !== '' ? $desc : null,
                 'parentId' => $parent !== '' ? $parent : null,
                 'created' => $created,
-                'size_mb' => 0,
+                'size_mb' => $sizeMb,
                 'xml' => $xml,
             ];
         }
@@ -774,6 +788,7 @@ public function listVmsBySceneInstance(string $instance_id)
             $tree = new \SimpleXMLElement($xml);
             $ctime = (string)$tree->creationTime;
             $created = $ctime ? date('c', (int)$ctime) : date('c');
+            $sizeMb = $this->calculateSnapshotSize($tree);
         } catch (\Throwable $e) {
             return response()->json(['error' => $e->getMessage()], 500);
         }
@@ -785,7 +800,7 @@ public function listVmsBySceneInstance(string $instance_id)
             'description' => $desc !== '' ? $desc : null,
             'parentId' => $parent !== '' ? $parent : null,
             'created' => $created,
-            'size_mb' => 0,
+            'size_mb' => $sizeMb,
             'xml' => $xml,
         ], 200);
     }

--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -737,14 +737,21 @@ public function listVmsBySceneInstance(string $instance_id)
                 $tree = new \SimpleXMLElement($xml);
                 $ctime = (string)$tree->creationTime;
                 $created = $ctime ? date('c', (int)$ctime) : date('c');
+                $desc = (string)($tree->description ?? '');
+                $parent = (string)($tree->parent->name ?? '');
             } catch (\Throwable $e) {
                 $created = date('c');
                 $xml = '';
+                $desc = '';
+                $parent = '';
             }
             $snaps[] = [
                 'id' => $name,
                 'name' => $name,
+                'description' => $desc !== '' ? $desc : null,
+                'parentId' => $parent !== '' ? $parent : null,
                 'created' => $created,
+                'size_mb' => 0,
                 'xml' => $xml,
             ];
         }
@@ -770,11 +777,15 @@ public function listVmsBySceneInstance(string $instance_id)
         } catch (\Throwable $e) {
             return response()->json(['error' => $e->getMessage()], 500);
         }
+        $desc = $data['description'] ?? (string)($tree->description ?? '');
+        $parent = (string)($tree->parent->name ?? '');
         return response()->json([
             'id' => $name,
             'name' => $name,
-            'description' => $data['description'] ?? null,
+            'description' => $desc !== '' ? $desc : null,
+            'parentId' => $parent !== '' ? $parent : null,
             'created' => $created,
+            'size_mb' => 0,
             'xml' => $xml,
         ], 200);
     }

--- a/src/app/scenario/vm-instances/page.tsx
+++ b/src/app/scenario/vm-instances/page.tsx
@@ -19,6 +19,9 @@ import {
     Checkbox,
     Switch,
     FormControlLabel,
+    Dialog,
+    DialogTitle,
+    DialogContent,
 } from "@mui/material";
 import {
     Search as SearchIcon,
@@ -45,6 +48,7 @@ import useSWR, { mutate as globalMutate } from "swr";
 // 保留 OverviewPanel 文件，但此页面不再使用
 //import OverviewPanel from "@/components/vm/OverviewPanel";
 import CreateVmModal from "@/components/vm/CreateVmModal";
+import SnapshotsPanel from "@/components/vm/SnapshotsPanel";
 
 /* ---------- 类型 ---------- */
 interface VmInstance {
@@ -165,6 +169,7 @@ export default function VmPage() {
         persistent: false,
         autostart: false,
     });
+    const [snapshotVmId, setSnapshotVmId] = React.useState<string | null>(null);
 
 
     /* ---- 列定义 ---- */
@@ -290,6 +295,9 @@ export default function VmPage() {
                                     </IconButton>
                                 </>
                             )}
+                            <IconButton size="small" onClick={() => setSnapshotVmId(vm.id)} disabled={actionLoading}>
+                                <SnapshotIcon fontSize="small" />
+                            </IconButton>
                             <IconButton size="small" onClick={() => handleDelete(vm)} disabled={actionLoading}>
                                 <DeleteIcon fontSize="small" color="error" />
                             </IconButton>
@@ -511,6 +519,12 @@ export default function VmPage() {
             <Backdrop open={actionLoading} sx={{ zIndex: theme.zIndex.modal + 1 }}>
                 <CircularProgress color="inherit" />
             </Backdrop>
+            <Dialog open={Boolean(snapshotVmId)} onClose={() => setSnapshotVmId(null)} fullWidth maxWidth="md">
+                <DialogTitle>快照管理</DialogTitle>
+                <DialogContent sx={{p:2}}>
+                    {snapshotVmId && <SnapshotsPanel vmId={snapshotVmId} />}
+                </DialogContent>
+            </Dialog>
             <CreateVmModal open={createOpen} onClose={() => setCreateOpen(false)} onCreated={() => mutate()} />
         </Box>
     );

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -55,20 +55,19 @@ export default function SnapshotsPanel({ vmId }: SnapshotsPanelProps) {
       }
       const data: Snapshot[] = await response.json();
       setSnapshots(data);
-      if (data.length > 0 && !selectedSnapshotId) {
-         // Select the newest snapshot by default if nothing is selected
+      setSelectedSnapshotId((prev) => {
+        if (data.length === 0) return null;
+        if (prev) return prev;
         const sortedSnaps = [...data].sort((a,b) => new Date(b.created).getTime() - new Date(a.created).getTime());
-        setSelectedSnapshotId(sortedSnaps[0].id);
-      } else if (data.length === 0) {
-        setSelectedSnapshotId(null);
-      }
+        return sortedSnaps[0].id;
+      });
     } catch (err: any) {
       setError(err.message || 'An unknown error occurred while fetching snapshots.');
       setSnapshots([]);
     } finally {
       setIsLoading(false);
     }
-  }, [selectedSnapshotId]); // Add selectedSnapshotId to dependencies if it influences initial selection logic
+  }, [vmId]);
 
   useEffect(() => {
     fetchSnapshots();
@@ -237,12 +236,10 @@ export default function SnapshotsPanel({ vmId }: SnapshotsPanelProps) {
                 <Typography variant="body2"><DescriptionIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Description:</strong> {selectedSnapshot.description || 'N/A'}</Typography>
                 <Typography variant="body2"><TreeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Parent:</strong> {snapshots.find(s => s.id === selectedSnapshot.parentId)?.name || 'None (Base)'}</Typography>
                 <Typography variant="body2"><SizeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Size:</strong> {selectedSnapshot.size_mb !== undefined ? `${selectedSnapshot.size_mb} MB` : 'N/A'}</Typography>
-                {selectedSnapshot.xml && <>
-                  <Typography variant="subtitle2" sx={{ mt: 2, pt:1, borderTop: '1px solid #eee' }}><XmlIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/> XML Configuration:</Typography>
-                  <Box sx={{ fontSize: '0.75rem', bgcolor: 'grey.100', p: 1.5, borderRadius: 1, maxHeight: 200, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                    {selectedSnapshot.xml}
-                  </Box>
-                </>}
+                <Typography variant="subtitle2" sx={{ mt: 2, pt:1, borderTop: '1px solid #eee' }}><XmlIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/> XML Configuration:</Typography>
+                <Box sx={{ fontSize: '0.75rem', bgcolor: 'grey.100', p: 1.5, borderRadius: 1, maxHeight: 200, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                  {selectedSnapshot.xml || 'N/A'}
+                </Box>
               </Stack>
             </Paper>
           ) : (

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -237,7 +237,20 @@ export default function SnapshotsPanel({ vmId }: SnapshotsPanelProps) {
                 <Typography variant="body2"><TreeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Parent:</strong> {snapshots.find(s => s.id === selectedSnapshot.parentId)?.name || 'None (Base)'}</Typography>
                 <Typography variant="body2"><SizeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Size:</strong> {selectedSnapshot.size_mb !== undefined ? `${selectedSnapshot.size_mb} MB` : 'N/A'}</Typography>
                 <Typography variant="subtitle2" sx={{ mt: 2, pt:1, borderTop: '1px solid #eee' }}><XmlIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/> XML Configuration:</Typography>
-                <Box sx={{ fontSize: '0.75rem', bgcolor: 'grey.100', p: 1.5, borderRadius: 1, maxHeight: 200, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                <Box
+                  sx={(theme) => ({
+                    fontSize: '0.75rem',
+                    bgcolor: theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[100],
+                    color: theme.palette.mode === 'dark' ? theme.palette.grey[100] : theme.palette.grey[800],
+                    fontFamily: 'monospace',
+                    p: 1.5,
+                    borderRadius: 1,
+                    maxHeight: 200,
+                    overflowY: 'auto',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-all',
+                  })}
+                >
                   {selectedSnapshot.xml || 'N/A'}
                 </Box>
               </Stack>

--- a/src/components/vm/SnapshotsPanel.tsx
+++ b/src/components/vm/SnapshotsPanel.tsx
@@ -164,7 +164,7 @@ export default function SnapshotsPanel({ vmId }: SnapshotsPanelProps) {
 
   const buildTree = useCallback((parentId: string | null = null): JSX.Element[] => {
     return snapshots
-      .filter(snapshot => snapshot.parentId === parentId)
+      .filter(snapshot => (snapshot.parentId ?? null) === parentId)
       .sort((a,b) => new Date(a.created).getTime() - new Date(b.created).getTime())
       .map(snapshot => (
         <TreeItem
@@ -236,7 +236,7 @@ export default function SnapshotsPanel({ vmId }: SnapshotsPanelProps) {
                 <Typography variant="body2"><CalendarIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Created:</strong> {new Date(selectedSnapshot.created).toLocaleString()}</Typography>
                 <Typography variant="body2"><DescriptionIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Description:</strong> {selectedSnapshot.description || 'N/A'}</Typography>
                 <Typography variant="body2"><TreeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Parent:</strong> {snapshots.find(s => s.id === selectedSnapshot.parentId)?.name || 'None (Base)'}</Typography>
-                <Typography variant="body2"><SizeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Size:</strong> {selectedSnapshot.size_mb} MB</Typography>
+                <Typography variant="body2"><SizeIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/><strong>Size:</strong> {selectedSnapshot.size_mb !== undefined ? `${selectedSnapshot.size_mb} MB` : 'N/A'}</Typography>
                 {selectedSnapshot.xml && <>
                   <Typography variant="subtitle2" sx={{ mt: 2, pt:1, borderTop: '1px solid #eee' }}><XmlIcon fontSize="small" sx={{verticalAlign: 'middle', mr:0.5}}/> XML Configuration:</Typography>
                   <Box sx={{ fontSize: '0.75rem', bgcolor: 'grey.100', p: 1.5, borderRadius: 1, maxHeight: 200, overflowY: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>


### PR DESCRIPTION
## Summary
- add snapshot management dialog to VM instances page
- improve snapshot panel tree handling and size fallback
- extend VM controller snapshot endpoints with metadata fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Trying to access array offset on null)*

------
https://chatgpt.com/codex/tasks/task_e_68b9833f17e08320a9566bda00715336