### PR TITLE
feat: add kibana log links for instance lists

### DIFF
--- a/src/app/ad/instances/ContainerInstancesTab.tsx
+++ b/src/app/ad/instances/ContainerInstancesTab.tsx
@@ -8,7 +8,8 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import {
     Refresh as RefreshIcon, Search as SearchIcon, PlayArrow as PlayArrowIcon,
     Stop as StopIcon, Delete as DeleteIcon, Pause as PauseIcon,
-    ViewColumn as ViewColumnIcon, MoreVert as MoreVertIcon, Flag as FlagIcon
+    ViewColumn as ViewColumnIcon, MoreVert as MoreVertIcon, Flag as FlagIcon,
+    Article as ArticleIcon
 } from '@mui/icons-material';
 
 import { RunningInstance, InstanceStatus } from '@/types';
@@ -20,6 +21,7 @@ import FlagSubmissionModal from '@/components/scenario/FlagSubmissionModal';
 import { useExecTerminal } from '@/contexts/ExecTerminalContext';
 import { useAuth } from '@/hooks/useAuth';
 import { customFetch } from '@/utils/fetch';
+import { v4 as uuidv4 } from 'uuid';
 
 const API_BASE = "/back";
 
@@ -151,6 +153,21 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         setIsConfirmDialogOpen(true);
     }, [fetchInstanceDetails, user]);
 
+    const handleOpenLogs = useCallback((instance: RunningInstance) => {
+        const base = process.env.NEXT_PUBLIC_KIBANA_BASE_URL || 'http://10.12.0.102:25601';
+        const version = process.env.NEXT_PUBLIC_KIBANA_VERSION || '';
+        const id = uuidv4();
+        const title = `${instance.scene_instance_id || ''}_${instance.name}`;
+        const params = encodeURIComponent(JSON.stringify({
+            dataViewSpec: { id, title, allowNoIndex: true },
+            columns: ["_source"],
+            query: { language: "kuery", query: "" },
+            filters: []
+        }));
+        const url = `${base}/app/r?l=DISCOVER_APP_LOCATOR&v=${version}&p=${params}`;
+        window.open(url, '_blank');
+    }, []);
+
     const columns: GridColDef[] = React.useMemo(() => [
         { field: 'name', headerName: '名称', flex: 1.5 },
         { field: 'status', headerName: '状态', width: 120, renderCell: (params) => (<Chip label={params.row.status} color={getStatusChipColor(params.row.status as InstanceStatus)} size="small" />)},
@@ -179,7 +196,7 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         { field: 'scene_name', headerName: '场景名称', width: 160, hide: !showColumns.scene_name },
         { field: 'id', headerName: '容器ID', flex: 1, hide: !showColumns.id, renderCell: (params) => <Tooltip title={params.value}><code>{params.value.substring(0,12)}...</code></Tooltip> },
         {
-            field: 'actions', headerName: '操作', sortable: false, width: 220,
+            field: 'actions', headerName: '操作', sortable: false, width: 260,
             renderCell: (params) => {
                 const instance = params.row as RunningInstance;
                 const isActionable = !['starting', 'stopping', 'deleting'].includes(instance.status);
@@ -220,12 +237,19 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
                                 </span>
                             </Tooltip>
                         )}
+                        <Tooltip title="日志">
+                            <span>
+                                <IconButton onClick={() => handleOpenLogs(instance)} size="small">
+                                    <ArticleIcon fontSize="small" />
+                                </IconButton>
+                            </span>
+                        </Tooltip>
                         <IconButton onClick={(e) => setMoreMenuAnchor({ anchor: e.currentTarget, id: instance.id })} size="small"><MoreVertIcon fontSize="small" /></IconButton>
                     </Box>
                 );
             }
         }
-    ], [showColumns, handleStartInstance, handleStopInstance, handlePauseInstance, handleDeleteInstance]);
+    ], [showColumns, handleStartInstance, handleStopInstance, handlePauseInstance, handleDeleteInstance, handleOpenLogs]);
 
     const filteredContainers = useMemo(() => {
         if (!searchTerm.trim()) return instances;

--- a/src/app/ad/instances/VmInstancesTab.tsx
+++ b/src/app/ad/instances/VmInstancesTab.tsx
@@ -39,10 +39,12 @@ import {
     ViewColumn as ViewColumnIcon,
     Refresh as RefreshIcon,
     Flag as FlagIcon,
+    Article as ArticleIcon,
 } from "@mui/icons-material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import useSWR, { mutate as globalMutate } from "swr";
 import FlagSubmissionModal from '@/components/scenario/FlagSubmissionModal';
+import { v4 as uuidv4 } from 'uuid';
 
 /* ---------- 类型定义 ---------- */
 interface VmInstance {
@@ -218,6 +220,21 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
         }
     };
 
+    const handleOpenLogs = React.useCallback((vm: VmInstance) => {
+        const base = process.env.NEXT_PUBLIC_KIBANA_BASE_URL || 'http://10.12.0.102:25601';
+        const version = process.env.NEXT_PUBLIC_KIBANA_VERSION || '';
+        const id = uuidv4();
+        const title = `${vm.scene_instance_id || ''}_${vm.name}`;
+        const params = encodeURIComponent(JSON.stringify({
+            dataViewSpec: { id, title, allowNoIndex: true },
+            columns: ["_source"],
+            query: { language: "kuery", query: "" },
+            filters: []
+        }));
+        const url = `${base}/app/r?l=DISCOVER_APP_LOCATOR&v=${version}&p=${params}`;
+        window.open(url, '_blank');
+    }, []);
+
     const columns = React.useMemo<GridColDef<VmInstance>[]>(
         () => [
             { field: 'status', headerName: '状态', width: 80, renderCell: (p) => <VmInfoCell id={p.row.id} width={20}>{d => stateIcon(d.status as any)}</VmInfoCell> },
@@ -247,7 +264,7 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
                 field: 'actions',
                 headerName: '操作',
                 sortable: false,
-                width: 200,
+                width: 240,
                 renderCell: (params) => {
                     const vm = params.row;
                     const { data: info } = useVmInfo(vm.id);
@@ -277,13 +294,20 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
                                     </span>
                                 </Tooltip>
                             )}
+                            <Tooltip title="日志">
+                                <span>
+                                    <IconButton onClick={() => handleOpenLogs(vm)} size="small">
+                                        <ArticleIcon fontSize="small" />
+                                    </IconButton>
+                                </span>
+                            </Tooltip>
                             <Tooltip title="更多操作"><IconButton size="small" onClick={(e) => setActionAnchor({ anchor: e.currentTarget, id: vm.id })}><ArrowDownIcon fontSize="small" /></IconButton></Tooltip>
                         </Box>
                     );
                 },
             },
         ],
-        [actionLoading, showColumns]
+        [actionLoading, showColumns, handleOpenLogs]
     );
 
     const filteredRows = React.useMemo(() => {

--- a/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
@@ -8,7 +8,8 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import {
     Refresh as RefreshIcon, Search as SearchIcon, PlayArrow as PlayArrowIcon,
     Stop as StopIcon, Delete as DeleteIcon, Pause as PauseIcon,
-    ViewColumn as ViewColumnIcon, MoreVert as MoreVertIcon, Flag as FlagIcon
+    ViewColumn as ViewColumnIcon, MoreVert as MoreVertIcon, Flag as FlagIcon,
+    Article as ArticleIcon
 } from '@mui/icons-material';
 
 import { RunningInstance, InstanceStatus } from '@/types';
@@ -20,6 +21,7 @@ import FlagSubmissionModal from '@/components/scenario/FlagSubmissionModal';
 import { useExecTerminal } from '@/contexts/ExecTerminalContext';
 import { useAuth } from '@/hooks/useAuth';
 import { customFetch } from '@/utils/fetch';
+import { v4 as uuidv4 } from 'uuid';
 
 const API_BASE = "/back";
 
@@ -151,6 +153,21 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         setIsConfirmDialogOpen(true);
     }, [fetchInstanceDetails, user]);
 
+    const handleOpenLogs = useCallback((instance: RunningInstance) => {
+        const base = process.env.NEXT_PUBLIC_KIBANA_BASE_URL || 'http://10.12.0.102:25601';
+        const version = process.env.NEXT_PUBLIC_KIBANA_VERSION || '';
+        const id = uuidv4();
+        const title = `${instance.scene_instance_id || ''}_${instance.name}`;
+        const params = encodeURIComponent(JSON.stringify({
+            dataViewSpec: { id, title, allowNoIndex: true },
+            columns: ["_source"],
+            query: { language: "kuery", query: "" },
+            filters: []
+        }));
+        const url = `${base}/app/r?l=DISCOVER_APP_LOCATOR&v=${version}&p=${params}`;
+        window.open(url, '_blank');
+    }, []);
+
     const columns: GridColDef[] = React.useMemo(() => [
         { field: 'name', headerName: '名称', flex: 1.5 },
         { field: 'status', headerName: '状态', width: 120, renderCell: (params) => (<Chip label={params.row.status} color={getStatusChipColor(params.row.status as InstanceStatus)} size="small" />)},
@@ -179,7 +196,7 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         { field: 'scene_name', headerName: '场景名称', width: 160, hide: !showColumns.scene_name },
         { field: 'id', headerName: '容器ID', flex: 1, hide: !showColumns.id, renderCell: (params) => <Tooltip title={params.value}><code>{params.value.substring(0,12)}...</code></Tooltip> },
         {
-            field: 'actions', headerName: '操作', sortable: false, width: 220,
+            field: 'actions', headerName: '操作', sortable: false, width: 260,
             renderCell: (params) => {
                 const instance = params.row as RunningInstance;
                 const isActionable = !['starting', 'stopping', 'deleting'].includes(instance.status);
@@ -220,12 +237,19 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
                                 </span>
                             </Tooltip>
                         )}
+                        <Tooltip title="日志">
+                            <span>
+                                <IconButton onClick={() => handleOpenLogs(instance)} size="small">
+                                    <ArticleIcon fontSize="small" />
+                                </IconButton>
+                            </span>
+                        </Tooltip>
                         <IconButton onClick={(e) => setMoreMenuAnchor({ anchor: e.currentTarget, id: instance.id })} size="small"><MoreVertIcon fontSize="small" /></IconButton>
                     </Box>
                 );
             }
         }
-    ], [showColumns, handleStartInstance, handleStopInstance, handlePauseInstance, handleDeleteInstance]);
+    ], [showColumns, handleStartInstance, handleStopInstance, handlePauseInstance, handleDeleteInstance, handleOpenLogs]);
 
     const filteredContainers = useMemo(() => {
         if (!searchTerm.trim()) return instances;

--- a/src/app/scenario/sceneinstances/VmInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/VmInstancesTab.tsx
@@ -39,10 +39,12 @@ import {
     ViewColumn as ViewColumnIcon,
     Refresh as RefreshIcon,
     Flag as FlagIcon,
+    Article as ArticleIcon,
 } from "@mui/icons-material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import useSWR, { mutate as globalMutate } from "swr";
 import FlagSubmissionModal from '@/components/scenario/FlagSubmissionModal';
+import { v4 as uuidv4 } from 'uuid';
 
 /* ---------- 类型定义 ---------- */
 interface VmInstance {
@@ -218,6 +220,21 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
         }
     };
 
+    const handleOpenLogs = React.useCallback((vm: VmInstance) => {
+        const base = process.env.NEXT_PUBLIC_KIBANA_BASE_URL || 'http://10.12.0.102:25601';
+        const version = process.env.NEXT_PUBLIC_KIBANA_VERSION || '';
+        const id = uuidv4();
+        const title = `${vm.scene_instance_id || ''}_${vm.name}`;
+        const params = encodeURIComponent(JSON.stringify({
+            dataViewSpec: { id, title, allowNoIndex: true },
+            columns: ["_source"],
+            query: { language: "kuery", query: "" },
+            filters: []
+        }));
+        const url = `${base}/app/r?l=DISCOVER_APP_LOCATOR&v=${version}&p=${params}`;
+        window.open(url, '_blank');
+    }, []);
+
     const columns = React.useMemo<GridColDef<VmInstance>[]>(
         () => [
             { field: 'status', headerName: '状态', width: 80, renderCell: (p) => <VmInfoCell id={p.row.id} width={20}>{d => stateIcon(d.status as any)}</VmInfoCell> },
@@ -247,7 +264,7 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
                 field: 'actions',
                 headerName: '操作',
                 sortable: false,
-                width: 200,
+                width: 240,
                 renderCell: (params) => {
                     const vm = params.row;
                     const { data: info } = useVmInfo(vm.id);
@@ -277,13 +294,20 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
                                     </span>
                                 </Tooltip>
                             )}
+                            <Tooltip title="日志">
+                                <span>
+                                    <IconButton onClick={() => handleOpenLogs(vm)} size="small">
+                                        <ArticleIcon fontSize="small" />
+                                    </IconButton>
+                                </span>
+                            </Tooltip>
                             <Tooltip title="更多操作"><IconButton size="small" onClick={(e) => setActionAnchor({ anchor: e.currentTarget, id: vm.id })}><ArrowDownIcon fontSize="small" /></IconButton></Tooltip>
                         </Box>
                     );
                 },
             },
         ],
-        [actionLoading, showColumns]
+        [actionLoading, showColumns, handleOpenLogs]
     );
 
     const filteredRows = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- add log buttons linking to Kibana in container and VM instance lists
- generate unique data view ID and use scene and instance names in title
- fall back to `http://10.12.0.102:25601` when `NEXT_PUBLIC_KIBANA_BASE_URL` is unset

## Testing
- `npm install` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdada090c8320b73ac8d2ac13ad85