### PR TITLE
feat: add command playback dialog and API

### DIFF
--- a/src/app/ad/instances/InstanceDetailsDialog.tsx
+++ b/src/app/ad/instances/InstanceDetailsDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import IngestControlDialog from '@/components/IngestControlDialog';
+import CommandPlaybackDialog from '@/components/CommandPlaybackDialog';
 
 // 导入新的标签页组件
 import ContainerInstancesTab from './ContainerInstancesTab'; // 替换旧的 docker.tsx
@@ -57,6 +58,7 @@ interface InstanceDetailsDialogProps {
 const InstanceDetailsDialog: React.FC<InstanceDetailsDialogProps> = ({ open, onClose, scenarioName, instanceId }) => {
     const [tabValue, setTabValue] = useState(0);
     const [ingestOpen, setIngestOpen] = useState(false);
+    const [playbackOpen, setPlaybackOpen] = useState(false);
 
     const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
         setTabValue(newValue);
@@ -73,6 +75,7 @@ const InstanceDetailsDialog: React.FC<InstanceDetailsDialogProps> = ({ open, onC
             <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 场景实例详情: {scenarioName}
                 <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                    <Button size="small" variant="outlined" onClick={() => setPlaybackOpen(true)}>指令回放</Button>
                     <Button size="small" variant="outlined" onClick={() => setIngestOpen(true)}>日志收集</Button>
                     <IconButton onClick={handleClose}><CloseIcon /></IconButton>
                 </Box>
@@ -104,6 +107,7 @@ const InstanceDetailsDialog: React.FC<InstanceDetailsDialogProps> = ({ open, onC
                 <Button onClick={handleClose}>关闭</Button>
             </DialogActions>
             <IngestControlDialog open={ingestOpen} onClose={() => setIngestOpen(false)} sceneInstanceId={instanceId} />
+            <CommandPlaybackDialog open={playbackOpen} onClose={() => setPlaybackOpen(false)} sceneInstanceId={instanceId} isAd />
         </Dialog>
     );
 };

--- a/src/app/api/command-playback/route.ts
+++ b/src/app/api/command-playback/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Client } from "@elastic/elasticsearch";
+import { z } from "zod";
+
+const es = new Client({
+    node: process.env.ES_NODE || "http://127.0.0.1:9200",
+    auth:
+        process.env.ES_USERNAME && process.env.ES_PASSWORD
+            ? { username: process.env.ES_USERNAME, password: process.env.ES_PASSWORD }
+            : undefined,
+    headers: {
+        accept: "application/vnd.elasticsearch+json; compatible-with=8",
+        "content-type": "application/vnd.elasticsearch+json; compatible-with=8",
+    },
+});
+
+const RequestSchema = z.object({
+    index: z.string(),
+    groupBy: z.enum(["user", "session"]).default("session"),
+    filterNoise: z.boolean().default(false),
+});
+
+const NOISE_COMMAND_PATTERNS = [
+    /^uname/,
+    /^file -b/,
+    /^groups$/,
+    /^dircolors/,
+];
+
+const SnoopyLogSchema = z
+    .object({
+        timestamp: z.string(),
+        cwd: z.string().optional().nullable(),
+        working_dir: z.string().optional().nullable(),
+        command: z.string().optional().nullable(),
+        full_command: z.string().optional().nullable(),
+        user: z.string().optional().nullable(),
+        uid: z.string().optional().nullable(),
+        sid: z.string().optional().nullable(),
+        session_id: z.string().optional().nullable(),
+    })
+    .transform((data) => ({
+        ts: new Date(data.timestamp),
+        user: data.user || data.uid || "unknown_user",
+        command: data.command || data.full_command || 'echo "UNKNOWN COMMAND"',
+        cwd: data.cwd || data.working_dir || "/",
+        sid: data.sid || data.session_id || "unknown_session",
+    }));
+
+async function fetchAllLogs(index: string) {
+    const allLogs: any[] = [];
+    const scrollSearch = es.helpers.scrollSearch({
+        index,
+        size: 1000,
+        query: { match: { from: "snoopy" } },
+        _source: [
+            "timestamp",
+            "cwd",
+            "working_dir",
+            "command",
+            "full_command",
+            "user",
+            "uid",
+            "sid",
+            "session_id",
+        ],
+    });
+    for await (const result of scrollSearch) {
+        allLogs.push(...result.documents);
+    }
+    return allLogs;
+}
+
+function filterNoiseCommands(logs: any[]) {
+    const logsByTimestamp = new Map<string, any[]>();
+    for (const log of logs) {
+        const timestampKey = log.ts.toISOString().slice(0, 19);
+        if (!logsByTimestamp.has(timestampKey)) {
+            logsByTimestamp.set(timestampKey, []);
+        }
+        logsByTimestamp.get(timestampKey)!.push(log);
+    }
+    const filteredLogs: any[] = [];
+    for (const [, group] of logsByTimestamp.entries()) {
+        if (group.length === 1) {
+            filteredLogs.push(group[0]);
+            continue;
+        }
+        const realCommands = group.filter(
+            (log) => !NOISE_COMMAND_PATTERNS.some((pattern) => pattern.test(log.command))
+        );
+        if (realCommands.length > 0) {
+            filteredLogs.push(...realCommands);
+        }
+    }
+    return filteredLogs;
+}
+
+export async function GET(req: NextRequest) {
+    const parse = RequestSchema.safeParse({
+        index: req.nextUrl.searchParams.get("index"),
+        groupBy: (req.nextUrl.searchParams.get("groupBy") as any) || "session",
+        filterNoise: req.nextUrl.searchParams.get("filterNoise") === "true",
+    });
+
+    if (!parse.success) {
+        return NextResponse.json({ ok: false, error: parse.error.flatten() }, { status: 400 });
+    }
+
+    const { index, groupBy, filterNoise } = parse.data;
+
+    let rawLogs = await fetchAllLogs(index);
+    if (!rawLogs || rawLogs.length === 0) {
+        return NextResponse.json({ groups: [] });
+    }
+
+    let validatedLogs = rawLogs
+        .map((log) => SnoopyLogSchema.safeParse(log))
+        .filter((result) => result.success)
+        .map((result) => result.data);
+
+    if (filterNoise) {
+        validatedLogs = filterNoiseCommands(validatedLogs);
+    }
+
+    validatedLogs.sort((a, b) => a.ts.getTime() - b.ts.getTime());
+
+    const groupingKey = groupBy === "user" ? "user" : "sid";
+    const groups: Record<string, any[]> = {};
+    for (const log of validatedLogs) {
+        const key = log[groupingKey];
+        if (!groups[key]) groups[key] = [];
+        groups[key].push({
+            timestamp: log.ts.toISOString(),
+            command: log.command,
+            cwd: log.cwd,
+            user: log.user,
+            sid: log.sid,
+        });
+    }
+
+    return NextResponse.json({
+        groups: Object.entries(groups).map(([key, logs]) => ({ key, logs })),
+    });
+}
+

--- a/src/app/scenario/sceneinstances/InstanceDetailsDialog.tsx
+++ b/src/app/scenario/sceneinstances/InstanceDetailsDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import IngestControlDialog from '@/components/IngestControlDialog';
+import CommandPlaybackDialog from '@/components/CommandPlaybackDialog';
 
 // 导入新的标签页组件
 import ContainerInstancesTab from './ContainerInstancesTab'; // 替换旧的 docker.tsx
@@ -57,6 +58,7 @@ interface InstanceDetailsDialogProps {
 const InstanceDetailsDialog: React.FC<InstanceDetailsDialogProps> = ({ open, onClose, scenarioName, instanceId }) => {
     const [tabValue, setTabValue] = useState(0);
     const [ingestOpen, setIngestOpen] = useState(false);
+    const [playbackOpen, setPlaybackOpen] = useState(false);
 
     const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
         setTabValue(newValue);
@@ -73,6 +75,7 @@ const InstanceDetailsDialog: React.FC<InstanceDetailsDialogProps> = ({ open, onC
             <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 场景实例详情: {scenarioName}
                 <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                    <Button size="small" variant="outlined" onClick={() => setPlaybackOpen(true)}>指令回放</Button>
                     <Button size="small" variant="outlined" onClick={() => setIngestOpen(true)}>日志收集</Button>
                     <IconButton onClick={handleClose}><CloseIcon /></IconButton>
                 </Box>
@@ -108,6 +111,7 @@ const InstanceDetailsDialog: React.FC<InstanceDetailsDialogProps> = ({ open, onC
                 <Button onClick={handleClose}>关闭</Button>
             </DialogActions>
             <IngestControlDialog open={ingestOpen} onClose={() => setIngestOpen(false)} sceneInstanceId={instanceId} />
+            <CommandPlaybackDialog open={playbackOpen} onClose={() => setPlaybackOpen(false)} sceneInstanceId={instanceId} />
         </Dialog>
     );
 };

--- a/src/components/CommandPlaybackDialog.tsx
+++ b/src/components/CommandPlaybackDialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+import React, { useMemo, useState } from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Box,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    Switch,
+    FormControlLabel,
+    CircularProgress,
+    List,
+    ListItem,
+    ListItemText,
+    Typography,
+    Accordion,
+    AccordionSummary,
+    AccordionDetails,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import useSWR from "swr";
+import { customFetch } from "@/utils/fetch";
+
+interface HostOption {
+    label: string;
+    index: string;
+}
+
+interface CommandPlaybackDialogProps {
+    open: boolean;
+    onClose: () => void;
+    sceneInstanceId: string | null;
+    isAd?: boolean;
+}
+
+const fetcher = (url: string) => customFetch(url).then((r) => r.json());
+
+export default function CommandPlaybackDialog({ open, onClose, sceneInstanceId, isAd }: CommandPlaybackDialogProps) {
+    const { data: vms } = useSWR(open && sceneInstanceId ? (isAd ? `/back/api/ad/vms/scene/${sceneInstanceId}` : `/back/api/scenariosinstances/${sceneInstanceId}/vms`) : null, fetcher);
+    const { data: containers } = useSWR(open && sceneInstanceId ? `/back/api/scenariosinstances/${sceneInstanceId}` : null, fetcher);
+
+    const hostOptions: HostOption[] = useMemo(() => {
+        const opts: HostOption[] = [];
+        if (vms) {
+            opts.push(
+                ...vms.map((vm: any) => ({
+                    label: `VM: ${vm.name}`,
+                    index: `${(vm.scene_instance_id || "")}_${vm.name}`.toLowerCase(),
+                }))
+            );
+        }
+        if (containers) {
+            opts.push(
+                ...containers.map((c: any) => ({
+                    label: `容器: ${c.name}`,
+                    index: `${(c.scene_instance_id || "")}_${c.name}`.toLowerCase(),
+                }))
+            );
+        }
+        return opts;
+    }, [vms, containers]);
+
+    const [selectedIndex, setSelectedIndex] = useState<string>("");
+    const [groupBy, setGroupBy] = useState<"session" | "user">("session");
+    const [filterNoise, setFilterNoise] = useState<boolean>(true);
+
+    const { data: playbackData, isValidating } = useSWR(() =>
+        selectedIndex
+            ? `/api/command-playback?index=${encodeURIComponent(selectedIndex)}&groupBy=${groupBy}&filterNoise=${filterNoise}`
+            : null,
+        fetcher
+    );
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg">
+            <DialogTitle>指令回放</DialogTitle>
+            <DialogContent dividers>
+                <Box sx={{ display: "flex", gap: 2, mb: 2, flexWrap: "wrap" }}>
+                    <FormControl sx={{ minWidth: 200 }} size="small">
+                        <InputLabel id="host-select-label">主机</InputLabel>
+                        <Select
+                            labelId="host-select-label"
+                            value={selectedIndex}
+                            label="主机"
+                            onChange={(e) => setSelectedIndex(e.target.value)}
+                        >
+                            {hostOptions.map((opt) => (
+                                <MenuItem key={opt.index} value={opt.index}>
+                                    {opt.label}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                    <FormControl sx={{ minWidth: 120 }} size="small">
+                        <InputLabel id="group-select-label">分组</InputLabel>
+                        <Select
+                            labelId="group-select-label"
+                            value={groupBy}
+                            label="分组"
+                            onChange={(e) => setGroupBy(e.target.value as any)}
+                        >
+                            <MenuItem value="session">会话</MenuItem>
+                            <MenuItem value="user">用户</MenuItem>
+                        </Select>
+                    </FormControl>
+                    <FormControlLabel
+                        control={<Switch checked={filterNoise} onChange={(e) => setFilterNoise(e.target.checked)} />}
+                        label="智能过滤"
+                    />
+                </Box>
+                {isValidating && <CircularProgress />}
+                {!isValidating && playbackData && playbackData.groups && playbackData.groups.length === 0 && (
+                    <Typography variant="body2">暂无数据</Typography>
+                )}
+                {!isValidating && playbackData?.groups?.map((group: any) => (
+                    <Accordion key={group.key} defaultExpanded>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography>{group.key}</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <List>
+                                {group.logs.map((log: any, idx: number) => (
+                                    <ListItem key={idx} alignItems="flex-start">
+                                        <ListItemText
+                                            primary={log.command}
+                                            secondary={`[${new Date(log.timestamp).toLocaleString()}] CWD: ${log.cwd}`}
+                                        />
+                                    </ListItem>
+                                ))}
+                            </List>
+                        </AccordionDetails>
+                    </Accordion>
+                ))}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>关闭</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add command playback button and dialog to instance detail pages
- implement reusable CommandPlaybackDialog with host selection and options
- provide `/api/command-playback` route to fetch grouped command logs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f9667cbc83208947f682f1e0c4b2