### PR TITLE
Fix playback all clearing queued timeouts

### DIFF
--- a/src/components/playback/PlaybackModal.tsx
+++ b/src/components/playback/PlaybackModal.tsx
@@ -341,11 +341,16 @@ export const PlaybackModal = ({ open, onClose, hosts }: PlaybackModalProps) => {
                 });
             }, delay);
         });
-
-        return () => {
-            Object.values(timeoutRef.current).forEach(clearTimeout);
-        }
     }, [playbackStates, data, hostMap, fixedInterval]);
+
+    useEffect(() => {
+        return () => {
+            Object.keys(timeoutRef.current).forEach(key => {
+                clearTimeout(timeoutRef.current[key]);
+                delete timeoutRef.current[key];
+            });
+        };
+    }, []);
 
 
     const handlePlaybackAction = async (key: string, action: 'play' | 'pause' | 'stop' | 'close') => {


### PR DESCRIPTION
## Summary
- prevent the playback scheduler cleanup from cancelling pending timeouts for other terminals
- add an unmount-only cleanup to clear any remaining timeouts when the component is disposed

## Testing
- npm install --no-progress *(fails: better-sqlite3 native build requirements in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf6a7f8fc8320b933e0cf5478a8aa