### PR TITLE
Hide advanced menus for target instances

### DIFF
--- a/src/components/learning/sceneinstances/ContainerInstancesTab.tsx
+++ b/src/components/learning/sceneinstances/ContainerInstancesTab.tsx
@@ -246,12 +246,23 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
                                 </IconButton>
                             </span>
                         </Tooltip>
-                        <IconButton onClick={(e) => setMoreMenuAnchor({ anchor: e.currentTarget, id: instance.id })} size="small"><MoreVertIcon fontSize="small" /></IconButton>
+                        {!isTarget && (
+                            <IconButton onClick={(e) => setMoreMenuAnchor({ anchor: e.currentTarget, id: instance.id })} size="small">
+                                <MoreVertIcon fontSize="small" />
+                            </IconButton>
+                        )}
                     </Box>
                 );
             }
         }
     ], [showColumns, handleStartInstance, handleStopInstance, handlePauseInstance, handleDeleteInstance, handleOpenLogs]);
+
+    const selectedInstance = useMemo(() => {
+        if (!moreMenuAnchor.id) {
+            return null;
+        }
+        return instances.find(instance => instance.id === moreMenuAnchor.id) || null;
+    }, [instances, moreMenuAnchor.id]);
 
     const filteredContainers = useMemo(() => {
         if (!searchTerm.trim()) return instances;
@@ -325,7 +336,11 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
                 ))}
             </Menu>
 
-            <Menu anchorEl={moreMenuAnchor.anchor} open={Boolean(moreMenuAnchor.anchor)} onClose={() => setMoreMenuAnchor({ anchor: null, id: null })}>
+            <Menu
+                anchorEl={selectedInstance && !selectedInstance.is_target ? moreMenuAnchor.anchor : null}
+                open={Boolean(selectedInstance && !selectedInstance.is_target && moreMenuAnchor.anchor)}
+                onClose={() => setMoreMenuAnchor({ anchor: null, id: null })}
+            >
                 <MenuItem onClick={() => { setLogsModalId(moreMenuAnchor.id); setMoreMenuAnchor({ anchor: null, id: null }); }}>
                     Logs
                 </MenuItem>

--- a/src/components/learning/sceneinstances/VmInstancesTab.tsx
+++ b/src/components/learning/sceneinstances/VmInstancesTab.tsx
@@ -156,6 +156,13 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
         is_target: true, // Added for the new column
     });
 
+    const selectedVm = React.useMemo(() => {
+        if (!actionAnchor.id) {
+            return null;
+        }
+        return data?.find(vm => vm.id === actionAnchor.id) ?? null;
+    }, [actionAnchor.id, data]);
+
     const handleLifecycle = async (vm: VmInstance, action: string) => {
         setActionLoading(true);
         forceRefreshUntil.current = Date.now() + 30_000;
@@ -304,7 +311,13 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
                                     </IconButton>
                                 </span>
                             </Tooltip>
-                            <Tooltip title="更多操作"><IconButton size="small" onClick={(e) => setActionAnchor({ anchor: e.currentTarget, id: vm.id })}><ArrowDownIcon fontSize="small" /></IconButton></Tooltip>
+                            {!isTarget && (
+                                <Tooltip title="更多操作">
+                                    <IconButton size="small" onClick={(e) => setActionAnchor({ anchor: e.currentTarget, id: vm.id })}>
+                                        <ArrowDownIcon fontSize="small" />
+                                    </IconButton>
+                                </Tooltip>
+                            )}
                         </Box>
                     );
                 },
@@ -382,7 +395,11 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
                 />
             </Box>
 
-            <Menu anchorEl={actionAnchor.anchor} open={Boolean(actionAnchor.anchor)} onClose={() => setActionAnchor({ anchor: null, id: null })}>
+            <Menu
+                anchorEl={selectedVm && !selectedVm.is_target ? actionAnchor.anchor : null}
+                open={Boolean(selectedVm && !selectedVm.is_target && actionAnchor.anchor)}
+                onClose={() => setActionAnchor({ anchor: null, id: null })}
+            >
                 {/*<MenuItem onClick={() => { const vm = data?.find(v=>v.id===actionAnchor.id); if(vm) handleGuac(vm,'ssh'); setActionAnchor({ anchor: null, id: null }); }}>
                     <SshIcon fontSize="small" sx={{ mr: 1 }} />
                     SSH


### PR DESCRIPTION
## Summary
- hide extra action menu entries for container targets to prevent unintended access
- prevent the virtual machine action menu from opening for target instances

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e220339550832091ed93e5ca5d7224