### PR TITLE
Add permission check to VM Guacamole access

### DIFF
--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -640,6 +640,7 @@ class VmController extends Controller
             $username = $request->input('username');
         }
 
+        $privilegedRole = null;
         $normalizedTeamId = $teamId !== null ? trim((string)$teamId) : '';
         if ($normalizedTeamId !== '') {
             if (!$username) {
@@ -650,28 +651,53 @@ class VmController extends Controller
             }
 
             try {
-                $isMember = DB::table('c_teams_users')
-                    ->where('team_id', $normalizedTeamId)
-                    ->where('user_id', $username)
-                    ->exists();
+                // 中文注释：查询用户的全部角色，用于判断是否拥有管理员等跨队伍访问权限
+                $roles = DB::table('c_users_roles')
+                    ->where('c_user_id', $username)
+                    ->pluck('c_role_id')
+                    ->map(fn ($role) => strtolower((string)$role));
             } catch (\Throwable $e) {
-                Log::error('Failed to verify team membership: ' . $e->getMessage());
+                Log::error('Failed to fetch user roles for Guac authority check: ' . $e->getMessage());
                 return response()->json([
                     'error' => '数据库查询失败',
                     'message' => '数据库查询失败',
                 ], 500);
             }
 
-            if (!$isMember) {
-                Log::warning('User lacks permission to access VM via Guac.', [
-                    'vm_name' => $vmName,
-                    'team_id' => $normalizedTeamId,
-                    'username' => $username,
-                ]);
-                return response()->json([
-                    'error' => '无权限访问该虚拟机',
-                    'message' => '用户不在该虚拟机所属队伍中',
-                ], 403);
+            $privilegedRoles = ['admin', 'guidance', 'operations', 'referee'];
+            foreach ($roles as $role) {
+                if (in_array($role, $privilegedRoles, true)) {
+                    // 中文注释：记录命中的特权角色，后续跳过队伍校验并向前端返回提示
+                    $privilegedRole = $role;
+                    break;
+                }
+            }
+
+            if (!$privilegedRole) {
+                try {
+                    $isMember = DB::table('c_teams_users')
+                        ->where('team_id', $normalizedTeamId)
+                        ->where('user_id', $username)
+                        ->exists();
+                } catch (\Throwable $e) {
+                    Log::error('Failed to verify team membership: ' . $e->getMessage());
+                    return response()->json([
+                        'error' => '数据库查询失败',
+                        'message' => '数据库查询失败',
+                    ], 500);
+                }
+
+                if (!$isMember) {
+                    Log::warning('User lacks permission to access VM via Guac.', [
+                        'vm_name' => $vmName,
+                        'team_id' => $normalizedTeamId,
+                        'username' => $username,
+                    ]);
+                    return response()->json([
+                        'error' => '无权限访问该虚拟机',
+                        'message' => '用户不在该虚拟机所属队伍中',
+                    ], 403);
+                }
             }
         }
 
@@ -698,12 +724,19 @@ class VmController extends Controller
             }
         }
 
-        return response()->json([
+        $response = [
             'host' => $ip ?? '无效',
             'ssh_port' => 22,
             'rdp_port' => 3389,
             'vnc_port' => $vncPort,
-        ], 200);
+        ];
+
+        if ($privilegedRole) {
+            // 中文注释：如果通过特权角色放行，则返回明确的提示信息，便于前端展示
+            $response['message'] = sprintf('用户角色 %s 拥有跨队伍访问权限', $privilegedRole);
+        }
+
+        return response()->json($response, 200);
     }
 
     // GET /vms/{vm_id}

--- a/back/app/Http/Controllers/Vm/VmController.php
+++ b/back/app/Http/Controllers/Vm/VmController.php
@@ -605,6 +605,107 @@ class VmController extends Controller
         ], 200);
     }
 
+    // GET /vms/{vm_name}/guac-with-authority
+    public function getGuacInfoWithAuthority($vmName, Request $request)
+    {
+        $method = strtolower($request->query('method', 'ssh'));
+        $vmQueryName = $request->query('vm_name', $vmName);
+
+        $record = null;
+        try {
+            $record = DB::table('c_scene_vm_instances')
+                ->where('c_vm_name', $vmQueryName)
+                ->select('c_ip', 'c_team_id')
+                ->first();
+        } catch (\Throwable $e) {
+            Log::error('Failed to fetch VM record for authority check: ' . $e->getMessage());
+            return response()->json([
+                'error' => '数据库查询失败',
+                'message' => '数据库查询失败',
+            ], 500);
+        }
+
+        $teamId = null;
+        $ipFromDb = null;
+        if ($record) {
+            $teamId = $record->c_team_id;
+            $ipFromDb = $record->c_ip;
+        }
+
+        $username = null;
+        $tokenData = $request->input('token_data');
+        if (is_array($tokenData) && isset($tokenData['id'])) {
+            $username = $tokenData['id'];
+        } elseif ($request->has('username')) {
+            $username = $request->input('username');
+        }
+
+        $normalizedTeamId = $teamId !== null ? trim((string)$teamId) : '';
+        if ($normalizedTeamId !== '') {
+            if (!$username) {
+                return response()->json([
+                    'error' => '无法识别当前用户',
+                    'message' => '用户信息缺失',
+                ], 401);
+            }
+
+            try {
+                $isMember = DB::table('c_teams_users')
+                    ->where('team_id', $normalizedTeamId)
+                    ->where('user_id', $username)
+                    ->exists();
+            } catch (\Throwable $e) {
+                Log::error('Failed to verify team membership: ' . $e->getMessage());
+                return response()->json([
+                    'error' => '数据库查询失败',
+                    'message' => '数据库查询失败',
+                ], 500);
+            }
+
+            if (!$isMember) {
+                Log::warning('User lacks permission to access VM via Guac.', [
+                    'vm_name' => $vmName,
+                    'team_id' => $normalizedTeamId,
+                    'username' => $username,
+                ]);
+                return response()->json([
+                    'error' => '无权限访问该虚拟机',
+                    'message' => '用户不在该虚拟机所属队伍中',
+                ], 403);
+            }
+        }
+
+        try {
+            $xml = $this->runVirsh('dumpxml', $vmName);
+            $vncPort = $this->parseVncPort($xml) ?? 5900;
+        } catch (\Throwable $e) {
+            $vncPort = 5900;
+        }
+
+        $ip = null;
+        if ($method === 'vnc') {
+            $ip = '127.0.0.1';
+            try {
+                $disp = trim($this->runVirsh('vncdisplay', $vmName));
+                if (preg_match('/:([0-9]+)$/', $disp, $m)) {
+                    $vncPort = 5900 + (int)$m[1];
+                }
+            } catch (\Throwable $e) {
+            }
+        } else {
+            if ($ipFromDb) {
+                $ip = explode('/', $ipFromDb)[0];
+            }
+        }
+
+        return response()->json([
+            'host' => $ip ?? '无效',
+            'ssh_port' => 22,
+            'rdp_port' => 3389,
+            'vnc_port' => $vncPort,
+        ], 200);
+    }
+
     // GET /vms/{vm_id}
     public function getVmInfo($vmId)
     {

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -248,6 +248,7 @@ Route::prefix('vms')->group(function () {
     Route::get('/image-options', [$c, 'listVmImageOptions']);
     Route::post('/create', [$c, 'createVm']);
     Route::get('/{vm_name}/guac', [$c, 'getGuacInfo']);
+    Route::get('/{vm_name}/guac-with-authority', [$c, 'getGuacInfoWithAuthority']);
     Route::get('/{vm_id}', [$c, 'getVmInfo']);
     Route::delete('/{vm_id}', [$c, 'deleteVm']);
     Route::post('/{vm_id}/actions/{action}', [$c, 'manageVmLifecycle']);

--- a/src/app/scenario/sceneinstances/VmInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/VmInstancesTab.tsx
@@ -80,6 +80,15 @@ interface VmInstancesTabProps {
     instanceId: string | null;
 }
 
+interface SupportUserResponse {
+    code: number;
+    message: string;
+    data?: {
+        c_username?: string;
+        [key: string]: unknown;
+    };
+}
+
 /* ---------- SWR Hooks ---------- */
 const fetcher = (url: string) => customFetch(url).then((r) => r.json());
 
@@ -139,6 +148,7 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
     const theme = useTheme();
     const forceRefreshUntil = React.useRef(0);
     const { data, isLoading, isValidating, mutate } = useVmInstances(instanceId, forceRefreshUntil);
+    const { data: currentUser } = useSWR<SupportUserResponse>('/back/api/support/user/id', fetcher);
 
     const [search, setSearch] = React.useState("");
     const [page, setPage] = React.useState(0);
@@ -155,6 +165,12 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
         ip: true,
         is_target: true, // Added for the new column
     });
+    const [blockedVnc, setBlockedVnc] = React.useState<Record<string, boolean>>({});
+
+    const selectedVm = React.useMemo(
+        () => data?.find((vm) => vm.id === actionAnchor.id) ?? null,
+        [data, actionAnchor.id]
+    );
 
     const handleLifecycle = async (vm: VmInstance, action: string) => {
         setActionLoading(true);
@@ -192,16 +208,54 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
     };
 
     const handleGuac = async (vmName: string, proto: 'ssh' | 'rdp' | 'vnc') => {
+        const params = new URLSearchParams({ method: proto, vm_name: vmName });
+        const username = currentUser?.data?.c_username;
+        if (username) {
+            params.append('username', username);
+        }
+
         try {
-            const res = await customFetch(`/back/api/vms/${vmName}/guac?method=${proto}&vm_name=${encodeURIComponent(vmName)}`);
-            if (!res.ok) throw new Error('Guacamole info request failed');
-            const info = await res.json();
+            const res = await customFetch(`/back/api/vms/${vmName}/guac-with-authority?${params.toString()}`);
+            let payload: any = null;
+            try {
+                payload = await res.json();
+            } catch (err) {
+                payload = null;
+            }
+
+            if (!res.ok) {
+                const message = payload?.error ?? payload?.message ?? 'Guacamole info request failed';
+                if (proto === 'vnc') {
+                    setBlockedVnc((prev) => ({ ...prev, [vmName]: true }));
+                }
+                console.log(`[Guac Authority] ${message}`);
+                const error = new Error(message);
+                (error as any).__alreadyLogged = true;
+                throw error;
+            }
+
+            if (!payload) {
+                throw new Error('Guacamole info response is invalid');
+            }
+
+            const info = payload;
             const port = proto === 'ssh' ? info.ssh_port : proto === 'rdp' ? info.rdp_port : info.vnc_port;
             openGuacWindow({ type: proto, hostname: info.host, port: String(port) });
+            if (proto === 'vnc') {
+                setBlockedVnc((prev) => {
+                    if (!prev[vmName]) return prev;
+                    const { [vmName]: _removed, ...rest } = prev;
+                    return rest;
+                });
+            }
         } catch (e: any) {
-            alert(e.message || 'Failed to open connection');
+            if (!e?.__alreadyLogged) {
+                console.log('打开连接失败：', e?.message ?? e);
+            }
+            alert(e?.message || 'Failed to open connection');
+        } finally {
+            setActionAnchor({ anchor: null, id: null });
         }
-        setActionAnchor({ anchor: null, id: null });
     };
 
     const handleDelete = async (vm: VmInstance) => {
@@ -385,15 +439,14 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
             </Box>
 
             <Menu anchorEl={actionAnchor.anchor} open={Boolean(actionAnchor.anchor)} onClose={() => setActionAnchor({ anchor: null, id: null })}>
-                {/*<MenuItem onClick={() => { const vm = data?.find(v=>v.id===actionAnchor.id); if(vm) handleGuac(vm,'ssh'); setActionAnchor({ anchor: null, id: null }); }}>
-                    <SshIcon fontSize="small" sx={{ mr: 1 }} />
-                    SSH
-                </MenuItem>
-                <MenuItem onClick={() => { const vm = data?.find(v=>v.id===actionAnchor.id); if(vm) handleGuac(vm,'rdp'); setActionAnchor({ anchor: null, id: null }); }}>
-                    <RdpIcon fontSize="small" sx={{ mr: 1 }} />
-                    RDP
-                </MenuItem>*/}
-                <MenuItem onClick={() => { const vm = data?.find(v=>v.id===actionAnchor.id); if(vm) handleGuac(vm.name,'vnc'); }}>
+                <MenuItem
+                    disabled={!selectedVm || !!blockedVnc[selectedVm.name]}
+                    onClick={() => {
+                        if (selectedVm) {
+                            handleGuac(selectedVm.name, 'vnc');
+                        }
+                    }}
+                >
                     <VncIcon fontSize="small" sx={{ mr: 1 }} /> VNC 控制台
                 </MenuItem>
             </Menu>

--- a/src/app/scenario/sceneinstances/VmInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/VmInstancesTab.tsx
@@ -46,6 +46,7 @@ import useSWR, { mutate as globalMutate } from "swr";
 import FlagSubmissionModal from '@/components/scenario/FlagSubmissionModal';
 import { v4 as uuidv4 } from 'uuid';
 import { customFetch } from '@/utils/fetch';
+import { useAuth } from '@/hooks/useAuth';
 
 /* ---------- 类型定义 ---------- */
 interface VmInstance {
@@ -147,8 +148,36 @@ function stateIcon(state: VmInstance["state"]) {
 const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
     const theme = useTheme();
     const forceRefreshUntil = React.useRef(0);
+    const { user: authUser } = useAuth();
+    const authUsername = React.useMemo(
+        () => ((authUser?.user as { c_username?: string } | undefined)?.c_username) ?? undefined,
+        [authUser]
+    );
+    const { data: currentUser, error: currentUserError } = useSWR<SupportUserResponse>(
+        authUsername ? ['/back/api/support/user/id', authUsername] : null,
+        ([url, id]) =>
+            customFetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id }),
+            }).then(async (res) => {
+                if (!res.ok) {
+                    const message = res.statusText || '获取用户信息失败';
+                    throw new Error(message);
+                }
+                return res.json();
+            }),
+        {
+            revalidateOnFocus: false,
+        }
+    );
+    const effectiveUsername = currentUser?.data?.c_username ?? authUsername;
+    React.useEffect(() => {
+        if (currentUserError) {
+            console.log(`[Guac Authority] 获取用户信息失败: ${currentUserError.message}`);
+        }
+    }, [currentUserError]);
     const { data, isLoading, isValidating, mutate } = useVmInstances(instanceId, forceRefreshUntil);
-    const { data: currentUser } = useSWR<SupportUserResponse>('/back/api/support/user/id', fetcher);
 
     const [search, setSearch] = React.useState("");
     const [page, setPage] = React.useState(0);
@@ -209,9 +238,14 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
 
     const handleGuac = async (vmName: string, proto: 'ssh' | 'rdp' | 'vnc') => {
         const params = new URLSearchParams({ method: proto, vm_name: vmName });
-        const username = currentUser?.data?.c_username;
-        if (username) {
-            params.append('username', username);
+        if (effectiveUsername) {
+            params.append('username', effectiveUsername);
+        } else {
+            const reason = currentUserError?.message || '当前用户信息尚未加载';
+            console.log(`[Guac Authority] ${reason}`);
+            alert(reason);
+            setActionAnchor({ anchor: null, id: null });
+            return;
         }
 
         try {
@@ -440,7 +474,7 @@ const VmInstancesTab: React.FC<VmInstancesTabProps> = ({ instanceId }) => {
 
             <Menu anchorEl={actionAnchor.anchor} open={Boolean(actionAnchor.anchor)} onClose={() => setActionAnchor({ anchor: null, id: null })}>
                 <MenuItem
-                    disabled={!selectedVm || !!blockedVnc[selectedVm.name]}
+                    disabled={!selectedVm || !!blockedVnc[selectedVm.name] || !effectiveUsername}
                     onClick={() => {
                         if (selectedVm) {
                             handleGuac(selectedVm.name, 'vnc');


### PR DESCRIPTION
## Summary
- add a Guacamole info endpoint with team-based permission checks on the backend
- register the new route for VMs so clients can request authority-protected connection details
- update the VM instances tab to use the new API, fetch the current user, and disable VNC when access is denied while logging the cause

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea29fec8488320969815fd1e9822ac