### PR TITLE
Add authority check for container terminal access

### DIFF
--- a/back/app/Http/Controllers/Docker/ContainersController.php
+++ b/back/app/Http/Controllers/Docker/ContainersController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Services\DockerService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class ContainersController extends Controller
 {
@@ -138,6 +139,108 @@ class ContainersController extends Controller
             'createdAt' => date('c', $detail->getCreated() ? strtotime($detail->getCreated()) : time()),
         ]);
     }
+
+    public function terminalWithAuthority(string $containerId, Request $request)
+    {
+        try {
+            $record = DB::table('c_scene_container_instances')
+                ->where('c_container_id', $containerId)
+                ->select('c_team_id')
+                ->first();
+        } catch (\Throwable $e) {
+            Log::error('Failed to fetch container record for authority check: ' . $e->getMessage());
+            return response()->json([
+                'error' => '数据库查询失败',
+                'message' => '数据库查询失败',
+            ], 500);
+        }
+
+        if (!$record) {
+            return response()->json([
+                'error' => '未找到容器实例',
+                'message' => '未找到容器实例',
+            ], 404);
+        }
+
+        $teamId = $record->c_team_id ?? null;
+        $normalizedTeamId = $teamId !== null ? trim((string) $teamId) : '';
+
+        if ($normalizedTeamId === '') {
+            return response()->json([
+                'allowed' => true,
+            ]);
+        }
+
+        $tokenData = $request->input('token_data');
+        $username = null;
+        if (is_array($tokenData) && isset($tokenData['id'])) {
+            $username = $tokenData['id'];
+        } elseif ($request->has('username')) {
+            $username = $request->input('username');
+        }
+
+        if (!$username) {
+            return response()->json([
+                'error' => '无法识别当前用户',
+                'message' => '用户信息缺失',
+            ], 401);
+        }
+
+        try {
+            $roles = DB::table('c_users_roles')
+                ->where('c_user_id', $username)
+                ->pluck('c_role_id')
+                ->map(fn ($role) => strtolower((string) $role));
+        } catch (\Throwable $e) {
+            Log::error('Failed to fetch user roles for container terminal authority check: ' . $e->getMessage());
+            return response()->json([
+                'error' => '数据库查询失败',
+                'message' => '数据库查询失败',
+            ], 500);
+        }
+
+        $privilegedRoles = ['admin', 'guidance', 'operations', 'referee'];
+        foreach ($roles as $role) {
+            if (in_array($role, $privilegedRoles, true)) {
+                return response()->json([
+                    'allowed' => true,
+                    'message' => sprintf('用户角色 %s 拥有跨队伍访问权限', $role),
+                ]);
+            }
+        }
+
+        try {
+            $isMember = DB::table('c_teams_users')
+                ->where('team_id', $normalizedTeamId)
+                ->where('user_id', $username)
+                ->exists();
+        } catch (\Throwable $e) {
+            Log::error('Failed to verify team membership for container terminal authority: ' . $e->getMessage());
+            return response()->json([
+                'error' => '数据库查询失败',
+                'message' => '数据库查询失败',
+            ], 500);
+        }
+
+        if (!$isMember) {
+            Log::warning('User lacks permission to access container terminal.', [
+                'container_id' => $containerId,
+                'team_id' => $normalizedTeamId,
+                'username' => $username,
+            ]);
+
+            return response()->json([
+                'allowed' => false,
+                'error' => '无权限访问该容器',
+                'message' => '用户不在该容器所属队伍中',
+            ], 403);
+        }
+
+        return response()->json([
+            'allowed' => true,
+        ]);
+    }
+
 //    /**
 //     * ★ 新增的方法 ★
 //     * 检查当前认证的用户是否有权操作指定的容器。

--- a/back/app/Http/Controllers/Docker/ContainersController.php
+++ b/back/app/Http/Controllers/Docker/ContainersController.php
@@ -177,6 +177,13 @@ class ContainersController extends Controller
             $username = $tokenData['id'];
         } elseif ($request->has('username')) {
             $username = $request->input('username');
+        } else {
+            $userPayload = $request->input('user');
+            if (is_array($userPayload) && isset($userPayload['c_username'])) {
+                $username = $userPayload['c_username'];
+            } elseif (is_object($userPayload) && isset($userPayload->c_username)) {
+                $username = $userPayload->c_username;
+            }
         }
 
         if (!$username) {

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -237,6 +237,7 @@ Route::prefix('containers')->group(function () {
     Route::get('/{id}/info', [ContainersController::class, 'info']);
     // 新增路由：检查容器操作权限
     Route::get('/{containerId}/can-operate', [ContainersController::class, 'checkPermission']);
+    Route::get('/{id}/terminal-with-authority', [ContainersController::class, 'terminalWithAuthority']);
 });
 
 

--- a/back/routes/api.php
+++ b/back/routes/api.php
@@ -237,7 +237,7 @@ Route::prefix('containers')->group(function () {
     Route::get('/{id}/info', [ContainersController::class, 'info']);
     // 新增路由：检查容器操作权限
     Route::get('/{containerId}/can-operate', [ContainersController::class, 'checkPermission']);
-    Route::get('/{id}/terminal-with-authority', [ContainersController::class, 'terminalWithAuthority']);
+    Route::match(['GET', 'POST'], '/{id}/terminal-with-authority', [ContainersController::class, 'terminalWithAuthority']);
 });
 
 

--- a/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
@@ -46,6 +46,7 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
     const [flagSubmissionModalId, setFlagSubmissionModalId] = useState<string | null>(null);
     const { openTerminal } = useExecTerminal();
     const [columnAnchorEl, setColumnAnchorEl] = useState<null | HTMLElement>(null);
+    const [permissionAlert, setPermissionAlert] = useState<{ type: 'info' | 'error'; message: string } | null>(null);
     const [showColumns, setShowColumns] = useState({
         id: false,
         is_target: true, // Added for the new column
@@ -264,8 +265,41 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         );
     }, [instances, searchTerm]);
 
+    const handleOpenTerminalWithAuthority = useCallback(async (containerId: string) => {
+        try {
+            const response = await customFetch(`${API_BASE}/api/containers/${containerId}/terminal-with-authority`);
+            let data: any = null;
+            try {
+                data = await response.clone().json();
+            } catch (err) {
+                data = null;
+            }
+
+            if (!response.ok || (data && data.allowed === false)) {
+                const message = data?.message || data?.error || '无权访问该容器终端';
+                setPermissionAlert({ type: 'error', message });
+                return;
+            }
+
+            if (data?.message) {
+                setPermissionAlert({ type: 'info', message: data.message });
+            } else {
+                setPermissionAlert(null);
+            }
+
+            openTerminal(containerId);
+        } catch (error) {
+            setPermissionAlert({ type: 'error', message: '终端权限校验失败，请稍后重试。' });
+        }
+    }, [openTerminal]);
+
     return (
         <Box>
+            {permissionAlert && (
+                <MuiAlert severity={permissionAlert.type} sx={{ mb: 2 }}>
+                    {permissionAlert.message}
+                </MuiAlert>
+            )}
              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 2 }}>
                   <Typography variant="h6">容器列表</Typography>
                   <TextField
@@ -337,7 +371,13 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
                 <MenuItem onClick={() => { setBindsModalId(moreMenuAnchor.id); setMoreMenuAnchor({ anchor: null, id: null }); }}>
                     Bind mounts
                 </MenuItem>
-                <MenuItem onClick={() => { if (moreMenuAnchor.id) openTerminal(moreMenuAnchor.id); setMoreMenuAnchor({ anchor: null, id: null }); }}>
+                <MenuItem onClick={() => {
+                    const id = moreMenuAnchor.id;
+                    setMoreMenuAnchor({ anchor: null, id: null });
+                    if (id) {
+                        void handleOpenTerminalWithAuthority(id);
+                    }
+                }}>
                     Terminal
                 </MenuItem>
             </Menu>

--- a/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
+++ b/src/app/scenario/sceneinstances/ContainerInstancesTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import useSWR from 'swr';
 import {
     Box, Typography, CircularProgress, Alert as MuiAlert, Paper, IconButton, Chip, Tooltip,
     TextField, InputAdornment, Switch, FormControlLabel, Menu, MenuItem, Button, useTheme
@@ -29,9 +30,51 @@ interface ContainerInstancesTabProps {
     instanceId: string | null;
 }
 
+interface SupportUserResponse {
+    code: number;
+    message: string;
+    data?: {
+        c_username?: string;
+        role?: string[];
+        [key: string]: unknown;
+    };
+}
+
 const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceId }) => {
     const theme = useTheme();
     const { user } = useAuth();
+    const authUsername = useMemo(
+        () => ((user?.user as { c_username?: string } | undefined)?.c_username) ?? undefined,
+        [user]
+    );
+    const { data: supportUserResponse, error: supportUserError } = useSWR<SupportUserResponse>(
+        authUsername ? ['/back/api/support/user/id', authUsername] : null,
+        ([url, id]) =>
+            customFetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id }),
+            }).then(async (res) => {
+                if (!res.ok) {
+                    const message = res.statusText || '获取用户信息失败';
+                    throw new Error(message);
+                }
+                return res.json();
+            }),
+        {
+            revalidateOnFocus: false,
+        }
+    );
+    useEffect(() => {
+        if (supportUserError) {
+            console.warn('[Container Terminal] 获取用户信息失败:', supportUserError.message);
+        }
+    }, [supportUserError]);
+    const supportUserData = supportUserResponse?.data;
+    const effectiveUsername = useMemo(
+        () => supportUserData?.c_username ?? authUsername,
+        [supportUserData?.c_username, authUsername]
+    );
 
     const [instances, setInstances] = useState<RunningInstance[]>([]);
     const [isLoading, setIsLoading] = useState(false);
@@ -267,7 +310,28 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
 
     const handleOpenTerminalWithAuthority = useCallback(async (containerId: string) => {
         try {
-            const response = await customFetch(`${API_BASE}/api/containers/${containerId}/terminal-with-authority`);
+            const payload: Record<string, unknown> = {};
+            if (effectiveUsername) {
+                payload.username = effectiveUsername;
+            }
+            if (supportUserData) {
+                payload.user = supportUserData;
+                if (Array.isArray(supportUserData.role)) {
+                    payload.roles = supportUserData.role;
+                }
+            }
+
+            const hasPayload = Object.keys(payload).length > 0;
+            const response = await customFetch(
+                `${API_BASE}/api/containers/${containerId}/terminal-with-authority`,
+                hasPayload
+                    ? {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify(payload),
+                      }
+                    : undefined
+            );
             let data: any = null;
             try {
                 data = await response.clone().json();
@@ -291,7 +355,7 @@ const ContainerInstancesTab: React.FC<ContainerInstancesTabProps> = ({ instanceI
         } catch (error) {
             setPermissionAlert({ type: 'error', message: '终端权限校验失败，请稍后重试。' });
         }
-    }, [openTerminal]);
+    }, [effectiveUsername, openTerminal, supportUserData]);
 
     return (
         <Box>


### PR DESCRIPTION
## Summary
- add a `terminalWithAuthority` endpoint on the container controller to validate terminal permissions
- expose the new API route for container terminal authority checks
- gate the scenario container terminal UI behind the new permission check and display feedback

## Testing
- php -l back/app/Http/Controllers/Docker/ContainersController.php

------
https://chatgpt.com/codex/tasks/task_e_68ea4d9736f8832088c95ffb02be98ed