### PR TITLE
Add system resource detail page with metrics APIs

### DIFF
--- a/src/app/api/system/cpu/route.ts
+++ b/src/app/api/system/cpu/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getCpuUsage } from '@/services/systemMetrics';
+
+export async function GET() {
+  try {
+    const cpu = await getCpuUsage();
+    return NextResponse.json(cpu);
+  } catch (error) {
+    console.error('Failed to read CPU usage', error);
+    return NextResponse.json({ message: 'Failed to read CPU usage' }, { status: 500 });
+  }
+}

--- a/src/app/api/system/disks/route.ts
+++ b/src/app/api/system/disks/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getDiskUsage } from '@/services/systemMetrics';
+
+export async function GET() {
+  try {
+    const disks = await getDiskUsage();
+    return NextResponse.json(disks);
+  } catch (error) {
+    console.error('Failed to read disk usage', error);
+    return NextResponse.json({ message: 'Failed to read disk usage' }, { status: 500 });
+  }
+}

--- a/src/app/api/system/memory/route.ts
+++ b/src/app/api/system/memory/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getMemoryUsage } from '@/services/systemMetrics';
+
+export async function GET() {
+  try {
+    const memory = getMemoryUsage();
+    return NextResponse.json(memory);
+  } catch (error) {
+    console.error('Failed to read memory usage', error);
+    return NextResponse.json({ message: 'Failed to read memory usage' }, { status: 500 });
+  }
+}

--- a/src/app/api/system/resources/route.ts
+++ b/src/app/api/system/resources/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getSystemResources } from '@/services/systemMetrics';
+
+export async function GET() {
+  try {
+    const data = await getSystemResources();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Failed to gather system resources', error);
+    return NextResponse.json({ message: 'Failed to gather system resources' }, { status: 500 });
+  }
+}

--- a/src/app/support/system-resources/page.tsx
+++ b/src/app/support/system-resources/page.tsx
@@ -254,6 +254,9 @@ const SystemResourcesPage: React.FC = () => {
     : (vmData as any)?.data ?? [];
 
   const primaryDisk = resources?.disks?.[0];
+  const cpuUsage = resources?.cpu?.usagePercent;
+  const cpuLoadAverage = resources?.cpu?.loadAverage ?? [];
+  const memoryUsage = resources?.memory;
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
@@ -268,9 +271,9 @@ const SystemResourcesPage: React.FC = () => {
             <ResourceCard
               title="CPU"
               icon={<MonitorHeartIcon color="primary" />}
-              value={resources ? `${resources.cpu.usagePercent.toFixed(1)}%` : '--'}
-              percent={resources?.cpu?.usagePercent}
-              helperText={resources ? `${resources.cpu.cores} 核 | 1/5/15 分钟负载 ${resources.cpu.loadAverage.map(v => v.toFixed(2)).join(' / ')}` : ''}
+              value={cpuUsage !== undefined ? `${cpuUsage.toFixed(1)}%` : '--'}
+              percent={cpuUsage}
+              helperText={resources?.cpu ? `${resources.cpu.cores} 核 | 1/5/15 分钟负载 ${cpuLoadAverage.map(v => v?.toFixed?.(2) ?? '--').join(' / ')}` : ''}
               loading={loadingResources}
             />
           </Grid>
@@ -278,9 +281,9 @@ const SystemResourcesPage: React.FC = () => {
             <ResourceCard
               title="内存"
               icon={<MemoryIcon color="primary" />}
-              value={resources ? `${formatBytes(resources.memory.used)} / ${formatBytes(resources.memory.total)}` : '--'}
-              percent={resources?.memory?.usedPercent}
-              helperText={resources ? `剩余 ${formatBytes(resources.memory.free)}` : ''}
+              value={memoryUsage ? `${formatBytes(memoryUsage.used)} / ${formatBytes(memoryUsage.total)}` : '--'}
+              percent={memoryUsage?.usedPercent}
+              helperText={memoryUsage ? `剩余 ${formatBytes(memoryUsage.free)}` : ''}
               loading={loadingResources}
             />
           </Grid>

--- a/src/app/support/system-resources/page.tsx
+++ b/src/app/support/system-resources/page.tsx
@@ -39,7 +39,6 @@ interface SystemResources {
   cpu: {
     cores: number;
     usagePercent: number;
-    loadAverage: number[];
   };
   memory: {
     total: number;
@@ -55,7 +54,7 @@ interface VmInstance {
   name: string;
   hostNode: string;
   pool: string;
-  state: "running" | "paused" | "shutoff";
+  state: "running" | "paused" | "shutoff" | "shut off";
   vcpu: number;
   vmem: number;
   ip?: string;
@@ -85,6 +84,7 @@ const statusColor = (status: string) => {
     case 'paused':
       return 'warning';
     case 'shutoff':
+    case 'shut off':
     case 'stopped':
       return 'default';
     default:
@@ -98,9 +98,44 @@ const statusIcon = (status: string) => {
       return <CheckCircleIcon fontSize="small" color="success" />;
     case 'paused':
       return <PauseCircleIcon fontSize="small" color="warning" />;
+    case 'shutoff':
+    case 'shut off':
+    case 'stopped':
+      return <PauseCircleIcon fontSize="small" color="action" />;
     default:
       return <ErrorIcon fontSize="small" color="error" />;
   }
+};
+
+const MetricSparkline = ({ data, color = '#1976d2' }: { data: number[]; color?: string }) => {
+  const width = 160;
+  const height = 48;
+
+  if (!data.length) {
+    return <Skeleton variant="rectangular" height={height} />;
+  }
+
+  const maxValue = Math.max(100, ...data);
+  const points = data
+    .map((value, index) => {
+      const x = (index / Math.max(data.length - 1, 1)) * width;
+      const y = height - (value / maxValue) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+      <polyline
+        fill="none"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        points={points}
+      />
+    </svg>
+  );
 };
 
 const ResourceCard = ({
@@ -109,7 +144,8 @@ const ResourceCard = ({
   percent,
   value,
   helperText,
-  loading
+  loading,
+  chart
 }: {
   title: string;
   icon: React.ReactNode;
@@ -117,6 +153,7 @@ const ResourceCard = ({
   value: string;
   helperText?: string;
   loading?: boolean;
+  chart?: React.ReactNode;
 }) => (
   <Card sx={{ height: '100%' }}>
     <CardContent>
@@ -128,13 +165,14 @@ const ResourceCard = ({
         {loading ? <Skeleton width={140} /> : value}
       </Typography>
       {percent !== undefined && (
-        <Box>
+        <Box sx={{ mb: 1 }}>
           <LinearProgress variant="determinate" value={percent} sx={{ height: 10, borderRadius: 1 }} />
           <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
             {percent.toFixed(1)}%
           </Typography>
         </Box>
       )}
+      {chart && <Box sx={{ mt: 1 }}>{chart}</Box>}
       {helperText && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
           {loading ? <Skeleton width={200} /> : helperText}
@@ -190,50 +228,6 @@ const DiskTable = ({ disks, loading }: { disks?: DiskUsage[]; loading?: boolean 
   </Paper>
 );
 
-const InstanceBlock = ({
-  title,
-  icon,
-  items,
-  typeKey
-}: {
-  title: string;
-  icon: React.ReactNode;
-  items: { id: string; name: string; status: string; extra?: string }[];
-  typeKey: 'vm' | 'container';
-}) => {
-  const running = items.filter(item => item.status === 'running').length;
-  return (
-    <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
-      <Stack direction="row" spacing={1} alignItems="center" mb={2}>
-        {icon}
-        <Typography variant="h6">{title}</Typography>
-        <Chip label={`运行中 ${running}/${items.length}`} color="primary" size="small" sx={{ ml: 'auto' }} />
-      </Stack>
-      {items.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">暂无数据</Typography>
-      ) : (
-        <Stack spacing={1.5}>
-          {items.slice(0, 6).map(item => (
-            <Box key={item.id} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {statusIcon(item.status)}
-                <Box>
-                  <Typography variant="subtitle2">{item.name}</Typography>
-                  {item.extra && <Typography variant="caption" color="text.secondary">{item.extra}</Typography>}
-                </Box>
-              </Box>
-              <Chip label={item.status} color={statusColor(item.status) as any} size="small" />
-            </Box>
-          ))}
-          {items.length > 6 && (
-            <Typography variant="caption" color="text.secondary">... 共 {items.length} 个{typeKey === 'vm' ? '虚拟机' : '容器'}</Typography>
-          )}
-        </Stack>
-      )}
-    </Paper>
-  );
-};
-
 const SystemResourcesPage: React.FC = () => {
   const { data: resources, isLoading: loadingResources } = useSWR<SystemResources>('/api/system/resources', fetcher, {
     refreshInterval: 10_000,
@@ -255,8 +249,52 @@ const SystemResourcesPage: React.FC = () => {
 
   const primaryDisk = resources?.disks?.[0];
   const cpuUsage = resources?.cpu?.usagePercent;
-  const cpuLoadAverage = resources?.cpu?.loadAverage ?? [];
   const memoryUsage = resources?.memory;
+
+  const [cpuHistory, setCpuHistory] = React.useState<number[]>([]);
+  const [memoryHistory, setMemoryHistory] = React.useState<number[]>([]);
+
+  React.useEffect(() => {
+    if (cpuUsage !== undefined) {
+      setCpuHistory(prev => [...prev.slice(-29), cpuUsage]);
+    }
+  }, [cpuUsage]);
+
+  React.useEffect(() => {
+    if (memoryUsage?.usedPercent !== undefined) {
+      setMemoryHistory(prev => [...prev.slice(-29), memoryUsage.usedPercent]);
+    }
+  }, [memoryUsage?.usedPercent]);
+
+  const instanceRows = React.useMemo(() => {
+    const containerRows = containers.map(container => ({
+      id: container.id,
+      name: container.name,
+      type: '容器',
+      status: container.status,
+      ip: container.ipAddress ?? '',
+      cpu: container.cpuUsage ?? '',
+      memory: container.memoryUsage ?? '',
+      disk: container.diskUsage ?? '',
+      scene: container.scene_name ?? '',
+      location: container.nodeId ?? ''
+    }));
+
+    const vmRows = vms.map(vm => ({
+      id: vm.id,
+      name: vm.name,
+      type: '虚拟机',
+      status: vm.state,
+      ip: vm.ip ?? '',
+      cpu: vm.vcpu ? `${vm.vcpu} vCPU` : '',
+      memory: vm.vmem ? `${vm.vmem} MB` : '',
+      disk: vm.uptime ?? '',
+      scene: vm.scene_name ?? '',
+      location: [vm.hostNode, vm.pool].filter(Boolean).join(' / ')
+    }));
+
+    return [...containerRows, ...vmRows];
+  }, [containers, vms]);
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
@@ -273,8 +311,9 @@ const SystemResourcesPage: React.FC = () => {
               icon={<MonitorHeartIcon color="primary" />}
               value={cpuUsage !== undefined ? `${cpuUsage.toFixed(1)}%` : '--'}
               percent={cpuUsage}
-              helperText={resources?.cpu ? `${resources.cpu.cores} 核 | 1/5/15 分钟负载 ${cpuLoadAverage.map(v => v?.toFixed?.(2) ?? '--').join(' / ')}` : ''}
+              helperText={resources?.cpu ? `${resources.cpu.cores} 核` : ''}
               loading={loadingResources}
+              chart={<MetricSparkline data={cpuHistory} color="#1976d2" />}
             />
           </Grid>
           <Grid item xs={12} md={4}>
@@ -285,6 +324,7 @@ const SystemResourcesPage: React.FC = () => {
               percent={memoryUsage?.usedPercent}
               helperText={memoryUsage ? `剩余 ${formatBytes(memoryUsage.free)}` : ''}
               loading={loadingResources}
+              chart={<MetricSparkline data={memoryHistory} color="#9c27b0" />}
             />
           </Grid>
           <Grid item xs={12} md={4}>
@@ -305,34 +345,57 @@ const SystemResourcesPage: React.FC = () => {
 
         <Box>
           <Typography variant="h5" fontWeight={600} gutterBottom>虚拟化与容器实例概览</Typography>
-          <Grid container spacing={2}>
-            <Grid item xs={12} md={6}>
-              <InstanceBlock
-                title="虚拟机实例"
-                icon={<DnsIcon color="primary" />}
-                items={vms.map(vm => ({
-                  id: vm.id,
-                  name: vm.name,
-                  status: vm.state,
-                  extra: vm.ip ? `IP: ${vm.ip}` : undefined
-                }))}
-                typeKey="vm"
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <InstanceBlock
-                title="容器实例"
-                icon={<RouterIcon color="primary" />}
-                items={containers.map(c => ({
-                  id: c.id,
-                  name: c.name,
-                  status: c.status,
-                  extra: c.ipAddress ? `IP: ${c.ipAddress}` : undefined
-                }))}
-                typeKey="container"
-              />
-            </Grid>
-          </Grid>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack direction="row" spacing={1} alignItems="center" mb={2}>
+              <DnsIcon color="primary" />
+              <RouterIcon color="primary" />
+              <Typography variant="h6">实例列表</Typography>
+              <Chip label={`总计 ${instanceRows.length}`} size="small" sx={{ ml: 'auto' }} />
+            </Stack>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>类型</TableCell>
+                  <TableCell>名称</TableCell>
+                  <TableCell>状态</TableCell>
+                  <TableCell>IP</TableCell>
+                  <TableCell>CPU</TableCell>
+                  <TableCell>内存</TableCell>
+                  <TableCell>磁盘 / 运行时长</TableCell>
+                  <TableCell>场景</TableCell>
+                  <TableCell>节点 / 资源池</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {instanceRows.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={9} align="center">
+                      <Typography variant="body2" color="text.secondary">暂无实例</Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  instanceRows.map(row => (
+                    <TableRow key={`${row.type}-${row.id}`}>
+                      <TableCell>{row.type}</TableCell>
+                      <TableCell>{row.name}</TableCell>
+                      <TableCell>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          {statusIcon(row.status)}
+                          <Chip label={row.status} color={statusColor(row.status) as any} size="small" />
+                        </Stack>
+                      </TableCell>
+                      <TableCell>{row.ip || '-'}</TableCell>
+                      <TableCell>{row.cpu || '-'}</TableCell>
+                      <TableCell>{row.memory || '-'}</TableCell>
+                      <TableCell>{row.disk || '-'}</TableCell>
+                      <TableCell>{row.scene || '-'}</TableCell>
+                      <TableCell>{row.location || '-'}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </Paper>
         </Box>
       </Stack>
     </Container>

--- a/src/app/support/system-resources/page.tsx
+++ b/src/app/support/system-resources/page.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   CardContent,
   Container,
-  Grid,
   LinearProgress,
   Stack,
   Table,
@@ -287,40 +286,44 @@ const SystemResourcesPage: React.FC = () => {
           <Typography variant="body1" color="text.secondary">查看服务器资源占用与虚拟化实例总体情况</Typography>
         </Box>
 
-        <Grid container spacing={2} columns={12}>
-          <Grid item xs={12} md={4}>
-            <ResourceCard
-              title="CPU"
-              icon={<MonitorHeartIcon color="primary" />}
-              value={cpuUsage !== undefined ? `${cpuUsage.toFixed(1)}%` : '--'}
-              percent={cpuUsage}
-              helperText={resources?.cpu ? `${resources.cpu.cores} 核` : ''}
-              loading={loadingResources}
-              chart={<MetricSparkline data={cpuHistory} color="#1976d2" />}
-            />
-          </Grid>
-          <Grid item xs={12} md={4}>
-            <ResourceCard
-              title="内存"
-              icon={<MemoryIcon color="primary" />}
-              value={memoryUsage ? `${formatBytes(memoryUsage.used)} / ${formatBytes(memoryUsage.total)}` : '--'}
-              percent={memoryUsage?.usedPercent}
-              helperText={memoryUsage ? `剩余 ${formatBytes(memoryUsage.free)}` : ''}
-              loading={loadingResources}
-              chart={<MetricSparkline data={memoryHistory} color="#9c27b0" />}
-            />
-          </Grid>
-          <Grid item xs={12} md={4}>
-            <ResourceCard
-              title="磁盘"
-              icon={<StorageIcon color="primary" />}
-              value={diskTotals ? `${formatBytes(diskTotals.usedKB * 1024)} / ${formatBytes(diskTotals.sizeKB * 1024)}` : '--'}
-              percent={diskTotals?.usedPercent}
-              helperText={diskTotals ? `共 ${resources?.disks?.length ?? 0} 个挂载` : '等待加载磁盘信息'}
-              loading={loadingResources}
-            />
-          </Grid>
-        </Grid>
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 2,
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: 'repeat(2, minmax(0, 1fr))',
+              md: 'repeat(3, minmax(0, 1fr))'
+            }
+          }}
+        >
+          <ResourceCard
+            title="CPU"
+            icon={<MonitorHeartIcon color="primary" />}
+            value={cpuUsage !== undefined ? `${cpuUsage.toFixed(1)}%` : '--'}
+            percent={cpuUsage}
+            helperText={resources?.cpu ? `${resources.cpu.cores} 核` : ''}
+            loading={loadingResources}
+            chart={<MetricSparkline data={cpuHistory} color="#1976d2" />}
+          />
+          <ResourceCard
+            title="内存"
+            icon={<MemoryIcon color="primary" />}
+            value={memoryUsage ? `${formatBytes(memoryUsage.used)} / ${formatBytes(memoryUsage.total)}` : '--'}
+            percent={memoryUsage?.usedPercent}
+            helperText={memoryUsage ? `剩余 ${formatBytes(memoryUsage.free)}` : ''}
+            loading={loadingResources}
+            chart={<MetricSparkline data={memoryHistory} color="#9c27b0" />}
+          />
+          <ResourceCard
+            title="磁盘"
+            icon={<StorageIcon color="primary" />}
+            value={diskTotals ? `${formatBytes(diskTotals.usedKB * 1024)} / ${formatBytes(diskTotals.sizeKB * 1024)}` : '--'}
+            percent={diskTotals?.usedPercent}
+            helperText={diskTotals ? `共 ${resources?.disks?.length ?? 0} 个挂载` : '等待加载磁盘信息'}
+            loading={loadingResources}
+          />
+        </Box>
 
         <Divider />
 

--- a/src/app/support/system-resources/page.tsx
+++ b/src/app/support/system-resources/page.tsx
@@ -19,7 +19,6 @@ import {
   Chip,
   Divider,
   Paper,
-  Tooltip,
   Skeleton,
 } from '@mui/material';
 import StorageIcon from '@mui/icons-material/Storage';
@@ -61,6 +60,12 @@ interface VmInstance {
   scene_instance_id?: string;
   scene_name?: string;
   uptime?: string;
+}
+
+interface VmDetailResponse {
+  vram?: {
+    total_mb?: number;
+  };
 }
 
 const fetcher = (url: string) => customFetch(url).then(res => res.json());
@@ -182,52 +187,6 @@ const ResourceCard = ({
   </Card>
 );
 
-const DiskTable = ({ disks, loading }: { disks?: DiskUsage[]; loading?: boolean }) => (
-  <Paper variant="outlined" sx={{ p: 2 }}>
-    <Stack direction="row" spacing={1} alignItems="center" mb={2}>
-      <StorageIcon color="primary" />
-      <Typography variant="h6">磁盘占用情况</Typography>
-    </Stack>
-    <Table size="small">
-      <TableHead>
-        <TableRow>
-          <TableCell>挂载点</TableCell>
-          <TableCell>文件系统</TableCell>
-          <TableCell>类型</TableCell>
-          <TableCell align="right">容量</TableCell>
-          <TableCell align="right">已用</TableCell>
-          <TableCell align="right">可用</TableCell>
-          <TableCell align="right">占用率</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {loading && (
-          <TableRow>
-            <TableCell colSpan={7}>
-              <LinearProgress />
-            </TableCell>
-          </TableRow>
-        )}
-        {!loading && disks?.map((disk) => (
-          <TableRow key={`${disk.filesystem}-${disk.mountpoint}`}>
-            <TableCell>{disk.mountpoint}</TableCell>
-            <TableCell>{disk.filesystem}</TableCell>
-            <TableCell>{disk.type || '未知'}</TableCell>
-            <TableCell align="right">{formatBytes(disk.sizeKB * 1024)}</TableCell>
-            <TableCell align="right">{formatBytes(disk.usedKB * 1024)}</TableCell>
-            <TableCell align="right">{formatBytes(disk.availKB * 1024)}</TableCell>
-            <TableCell align="right">
-              <Tooltip title={`${disk.usedPercent}%`}>
-                <LinearProgress variant="determinate" value={disk.usedPercent} sx={{ height: 8, borderRadius: 1 }} />
-              </Tooltip>
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  </Paper>
-);
-
 const SystemResourcesPage: React.FC = () => {
   const { data: resources, isLoading: loadingResources } = useSWR<SystemResources>('/api/system/resources', fetcher, {
     refreshInterval: 10_000,
@@ -247,7 +206,33 @@ const SystemResourcesPage: React.FC = () => {
     ? vmData
     : (vmData as any)?.data ?? [];
 
-  const primaryDisk = resources?.disks?.[0];
+  const { data: vmDetails } = useSWR<Record<string, VmDetailResponse> | null>(
+    vms.length ? ['vm-details', vms.map(vm => vm.id).join(',')] : null,
+    async () => {
+      const entries = await Promise.all(
+        vms.map(async vm => {
+          try {
+            const detail = await fetcher(`/back/api/vms/${vm.id}`);
+            return [vm.id, detail as VmDetailResponse];
+          } catch (error) {
+            console.error('Failed to fetch vm detail', vm.id, error);
+            return [vm.id, null];
+          }
+        })
+      );
+
+      return Object.fromEntries(entries);
+    },
+    { refreshInterval: 20_000 }
+  );
+
+  const diskTotals = React.useMemo(() => {
+    if (!resources?.disks?.length) return undefined;
+    const sizeKB = resources.disks.reduce((acc, disk) => acc + (disk.sizeKB || 0), 0);
+    const usedKB = resources.disks.reduce((acc, disk) => acc + (disk.usedKB || 0), 0);
+    const usedPercent = sizeKB > 0 ? (usedKB / sizeKB) * 100 : 0;
+    return { sizeKB, usedKB, usedPercent };
+  }, [resources?.disks]);
   const cpuUsage = resources?.cpu?.usagePercent;
   const memoryUsage = resources?.memory;
 
@@ -275,9 +260,8 @@ const SystemResourcesPage: React.FC = () => {
       ip: container.ipAddress ?? '',
       cpu: container.cpuUsage ?? '',
       memory: container.memoryUsage ?? '',
-      disk: container.diskUsage ?? '',
-      scene: container.scene_name ?? '',
-      location: container.nodeId ?? ''
+      disk: container.uptime ?? '',
+      scene: container.scene_name ?? ''
     }));
 
     const vmRows = vms.map(vm => ({
@@ -287,24 +271,23 @@ const SystemResourcesPage: React.FC = () => {
       status: vm.state,
       ip: vm.ip ?? '',
       cpu: vm.vcpu ? `${vm.vcpu} vCPU` : '',
-      memory: vm.vmem ? `${vm.vmem} MB` : '',
+      memory: vmDetails?.[vm.id]?.vram?.total_mb ? `${vmDetails[vm.id].vram!.total_mb} MB` : vm.vmem ? `${vm.vmem} MB` : '',
       disk: vm.uptime ?? '',
-      scene: vm.scene_name ?? '',
-      location: [vm.hostNode, vm.pool].filter(Boolean).join(' / ')
+      scene: vm.scene_name ?? ''
     }));
 
     return [...containerRows, ...vmRows];
-  }, [containers, vms]);
+  }, [containers, vms, vmDetails]);
 
   return (
-    <Container maxWidth="lg" sx={{ py: 3 }}>
+    <Container maxWidth="xl" sx={{ py: 3 }}>
       <Stack spacing={2}>
         <Box>
           <Typography variant="h4" fontWeight={700}>系统资源详情</Typography>
           <Typography variant="body1" color="text.secondary">查看服务器资源占用与虚拟化实例总体情况</Typography>
         </Box>
 
-        <Grid container spacing={2}>
+        <Grid container spacing={2} columns={12}>
           <Grid item xs={12} md={4}>
             <ResourceCard
               title="CPU"
@@ -331,15 +314,13 @@ const SystemResourcesPage: React.FC = () => {
             <ResourceCard
               title="磁盘"
               icon={<StorageIcon color="primary" />}
-              value={primaryDisk ? `${formatBytes(primaryDisk.usedKB * 1024)} / ${formatBytes(primaryDisk.sizeKB * 1024)}` : '--'}
-              percent={primaryDisk?.usedPercent}
-              helperText={primaryDisk ? `挂载点 ${primaryDisk.mountpoint}` : '等待加载磁盘信息'}
+              value={diskTotals ? `${formatBytes(diskTotals.usedKB * 1024)} / ${formatBytes(diskTotals.sizeKB * 1024)}` : '--'}
+              percent={diskTotals?.usedPercent}
+              helperText={diskTotals ? `共 ${resources?.disks?.length ?? 0} 个挂载` : '等待加载磁盘信息'}
               loading={loadingResources}
             />
           </Grid>
         </Grid>
-
-        <DiskTable disks={resources?.disks} loading={loadingResources} />
 
         <Divider />
 
@@ -361,15 +342,14 @@ const SystemResourcesPage: React.FC = () => {
                   <TableCell>IP</TableCell>
                   <TableCell>CPU</TableCell>
                   <TableCell>内存</TableCell>
-                  <TableCell>磁盘 / 运行时长</TableCell>
+                  <TableCell>运行时长 / 磁盘</TableCell>
                   <TableCell>场景</TableCell>
-                  <TableCell>节点 / 资源池</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {instanceRows.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={9} align="center">
+                    <TableCell colSpan={8} align="center">
                       <Typography variant="body2" color="text.secondary">暂无实例</Typography>
                     </TableCell>
                   </TableRow>
@@ -389,7 +369,6 @@ const SystemResourcesPage: React.FC = () => {
                       <TableCell>{row.memory || '-'}</TableCell>
                       <TableCell>{row.disk || '-'}</TableCell>
                       <TableCell>{row.scene || '-'}</TableCell>
-                      <TableCell>{row.location || '-'}</TableCell>
                     </TableRow>
                   ))
                 )}

--- a/src/app/support/system-resources/page.tsx
+++ b/src/app/support/system-resources/page.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import React from 'react';
+import useSWR from 'swr';
+import {
+  Box,
+  Card,
+  CardContent,
+  Container,
+  Grid,
+  LinearProgress,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+  Chip,
+  Divider,
+  Paper,
+  Tooltip,
+  Skeleton,
+} from '@mui/material';
+import StorageIcon from '@mui/icons-material/Storage';
+import MemoryIcon from '@mui/icons-material/Memory';
+import MonitorHeartIcon from '@mui/icons-material/MonitorHeart';
+import DnsIcon from '@mui/icons-material/Dns';
+import RouterIcon from '@mui/icons-material/Router';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import PauseCircleIcon from '@mui/icons-material/PauseCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+
+import { customFetch } from '@/utils/fetch';
+import { RunningInstance } from '@/types';
+import { DiskUsage } from '@/services/systemMetrics';
+
+interface SystemResources {
+  cpu: {
+    cores: number;
+    usagePercent: number;
+    loadAverage: number[];
+  };
+  memory: {
+    total: number;
+    used: number;
+    free: number;
+    usedPercent: number;
+  };
+  disks: DiskUsage[];
+}
+
+interface VmInstance {
+  id: string;
+  name: string;
+  hostNode: string;
+  pool: string;
+  state: "running" | "paused" | "shutoff";
+  vcpu: number;
+  vmem: number;
+  ip?: string;
+  scene_instance_id?: string;
+  scene_name?: string;
+  uptime?: string;
+}
+
+const fetcher = (url: string) => customFetch(url).then(res => res.json());
+
+const formatBytes = (bytes: number) => {
+  if (!bytes && bytes !== 0) return '未知';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value.toFixed(1)} ${units[index]}`;
+};
+
+const statusColor = (status: string) => {
+  switch (status) {
+    case 'running':
+      return 'success';
+    case 'paused':
+      return 'warning';
+    case 'shutoff':
+    case 'stopped':
+      return 'default';
+    default:
+      return 'error';
+  }
+};
+
+const statusIcon = (status: string) => {
+  switch (status) {
+    case 'running':
+      return <CheckCircleIcon fontSize="small" color="success" />;
+    case 'paused':
+      return <PauseCircleIcon fontSize="small" color="warning" />;
+    default:
+      return <ErrorIcon fontSize="small" color="error" />;
+  }
+};
+
+const ResourceCard = ({
+  title,
+  icon,
+  percent,
+  value,
+  helperText,
+  loading
+}: {
+  title: string;
+  icon: React.ReactNode;
+  percent?: number;
+  value: string;
+  helperText?: string;
+  loading?: boolean;
+}) => (
+  <Card sx={{ height: '100%' }}>
+    <CardContent>
+      <Stack direction="row" spacing={1} alignItems="center" mb={1}>
+        {icon}
+        <Typography variant="subtitle1">{title}</Typography>
+      </Stack>
+      <Typography variant="h4" component="div" sx={{ fontWeight: 600, mb: 1 }}>
+        {loading ? <Skeleton width={140} /> : value}
+      </Typography>
+      {percent !== undefined && (
+        <Box>
+          <LinearProgress variant="determinate" value={percent} sx={{ height: 10, borderRadius: 1 }} />
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {percent.toFixed(1)}%
+          </Typography>
+        </Box>
+      )}
+      {helperText && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          {loading ? <Skeleton width={200} /> : helperText}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const DiskTable = ({ disks, loading }: { disks?: DiskUsage[]; loading?: boolean }) => (
+  <Paper variant="outlined" sx={{ p: 2 }}>
+    <Stack direction="row" spacing={1} alignItems="center" mb={2}>
+      <StorageIcon color="primary" />
+      <Typography variant="h6">磁盘占用情况</Typography>
+    </Stack>
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>挂载点</TableCell>
+          <TableCell>文件系统</TableCell>
+          <TableCell>类型</TableCell>
+          <TableCell align="right">容量</TableCell>
+          <TableCell align="right">已用</TableCell>
+          <TableCell align="right">可用</TableCell>
+          <TableCell align="right">占用率</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {loading && (
+          <TableRow>
+            <TableCell colSpan={7}>
+              <LinearProgress />
+            </TableCell>
+          </TableRow>
+        )}
+        {!loading && disks?.map((disk) => (
+          <TableRow key={`${disk.filesystem}-${disk.mountpoint}`}>
+            <TableCell>{disk.mountpoint}</TableCell>
+            <TableCell>{disk.filesystem}</TableCell>
+            <TableCell>{disk.type || '未知'}</TableCell>
+            <TableCell align="right">{formatBytes(disk.sizeKB * 1024)}</TableCell>
+            <TableCell align="right">{formatBytes(disk.usedKB * 1024)}</TableCell>
+            <TableCell align="right">{formatBytes(disk.availKB * 1024)}</TableCell>
+            <TableCell align="right">
+              <Tooltip title={`${disk.usedPercent}%`}>
+                <LinearProgress variant="determinate" value={disk.usedPercent} sx={{ height: 8, borderRadius: 1 }} />
+              </Tooltip>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </Paper>
+);
+
+const InstanceBlock = ({
+  title,
+  icon,
+  items,
+  typeKey
+}: {
+  title: string;
+  icon: React.ReactNode;
+  items: { id: string; name: string; status: string; extra?: string }[];
+  typeKey: 'vm' | 'container';
+}) => {
+  const running = items.filter(item => item.status === 'running').length;
+  return (
+    <Paper variant="outlined" sx={{ p: 2, height: '100%' }}>
+      <Stack direction="row" spacing={1} alignItems="center" mb={2}>
+        {icon}
+        <Typography variant="h6">{title}</Typography>
+        <Chip label={`运行中 ${running}/${items.length}`} color="primary" size="small" sx={{ ml: 'auto' }} />
+      </Stack>
+      {items.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">暂无数据</Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {items.slice(0, 6).map(item => (
+            <Box key={item.id} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {statusIcon(item.status)}
+                <Box>
+                  <Typography variant="subtitle2">{item.name}</Typography>
+                  {item.extra && <Typography variant="caption" color="text.secondary">{item.extra}</Typography>}
+                </Box>
+              </Box>
+              <Chip label={item.status} color={statusColor(item.status) as any} size="small" />
+            </Box>
+          ))}
+          {items.length > 6 && (
+            <Typography variant="caption" color="text.secondary">... 共 {items.length} 个{typeKey === 'vm' ? '虚拟机' : '容器'}</Typography>
+          )}
+        </Stack>
+      )}
+    </Paper>
+  );
+};
+
+const SystemResourcesPage: React.FC = () => {
+  const { data: resources, isLoading: loadingResources } = useSWR<SystemResources>('/api/system/resources', fetcher, {
+    refreshInterval: 10_000,
+  });
+
+  const { data: containerData } = useSWR<RunningInstance[] | { data: RunningInstance[] }>('/back/api/instances', fetcher, {
+    refreshInterval: 20_000,
+  });
+  const { data: vmData } = useSWR<VmInstance[] | { data: VmInstance[] }>('/back/api/vms', fetcher, {
+    refreshInterval: 20_000,
+  });
+
+  const containers: RunningInstance[] = Array.isArray(containerData)
+    ? containerData
+    : (containerData as any)?.data ?? [];
+  const vms: VmInstance[] = Array.isArray(vmData)
+    ? vmData
+    : (vmData as any)?.data ?? [];
+
+  const primaryDisk = resources?.disks?.[0];
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      <Stack spacing={2}>
+        <Box>
+          <Typography variant="h4" fontWeight={700}>系统资源详情</Typography>
+          <Typography variant="body1" color="text.secondary">查看服务器资源占用与虚拟化实例总体情况</Typography>
+        </Box>
+
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={4}>
+            <ResourceCard
+              title="CPU"
+              icon={<MonitorHeartIcon color="primary" />}
+              value={resources ? `${resources.cpu.usagePercent.toFixed(1)}%` : '--'}
+              percent={resources?.cpu?.usagePercent}
+              helperText={resources ? `${resources.cpu.cores} 核 | 1/5/15 分钟负载 ${resources.cpu.loadAverage.map(v => v.toFixed(2)).join(' / ')}` : ''}
+              loading={loadingResources}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <ResourceCard
+              title="内存"
+              icon={<MemoryIcon color="primary" />}
+              value={resources ? `${formatBytes(resources.memory.used)} / ${formatBytes(resources.memory.total)}` : '--'}
+              percent={resources?.memory?.usedPercent}
+              helperText={resources ? `剩余 ${formatBytes(resources.memory.free)}` : ''}
+              loading={loadingResources}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <ResourceCard
+              title="磁盘"
+              icon={<StorageIcon color="primary" />}
+              value={primaryDisk ? `${formatBytes(primaryDisk.usedKB * 1024)} / ${formatBytes(primaryDisk.sizeKB * 1024)}` : '--'}
+              percent={primaryDisk?.usedPercent}
+              helperText={primaryDisk ? `挂载点 ${primaryDisk.mountpoint}` : '等待加载磁盘信息'}
+              loading={loadingResources}
+            />
+          </Grid>
+        </Grid>
+
+        <DiskTable disks={resources?.disks} loading={loadingResources} />
+
+        <Divider />
+
+        <Box>
+          <Typography variant="h5" fontWeight={600} gutterBottom>虚拟化与容器实例概览</Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={6}>
+              <InstanceBlock
+                title="虚拟机实例"
+                icon={<DnsIcon color="primary" />}
+                items={vms.map(vm => ({
+                  id: vm.id,
+                  name: vm.name,
+                  status: vm.state,
+                  extra: vm.ip ? `IP: ${vm.ip}` : undefined
+                }))}
+                typeKey="vm"
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <InstanceBlock
+                title="容器实例"
+                icon={<RouterIcon color="primary" />}
+                items={containers.map(c => ({
+                  id: c.id,
+                  name: c.name,
+                  status: c.status,
+                  extra: c.ipAddress ? `IP: ${c.ipAddress}` : undefined
+                }))}
+                typeKey="container"
+              />
+            </Grid>
+          </Grid>
+        </Box>
+      </Stack>
+    </Container>
+  );
+};
+
+export default SystemResourcesPage;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -71,6 +71,7 @@ const Sidebar: React.FC<SidebarProps> = ({ drawerWidth }) => {
     if (currentPath.startsWith('/drill')) initialOpenMenus["安全实验分系统"] = true; // Updated key
     if (
       currentPath.startsWith('/admin') ||
+      currentPath.startsWith('/support/system-resources') ||
       currentPath.startsWith('/scenario/images') ||
       currentPath.startsWith('/scenario/instances') ||
       currentPath.startsWith('/scenario/vm-images') ||

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,8 @@ export const APP_PERMISSIONS: AppPermission[] = [
       { label: "容器镜像管理", key: 'support_images_manage' }, // Moved here and renamed
       { label: "容器实例管理", key: 'support_instances_manage' }, // Moved here and renamed
       { label: "虚拟机镜像管理", key: 'support_scenario_images_manage' },
-      { label: "虚拟机实例管理", key: 'support_scenario_instances_manage' }
+      { label: "虚拟机实例管理", key: 'support_scenario_instances_manage' },
+      { label: "系统资源详情", key: 'support_system_resources' }
     ]
   }
 ];

--- a/src/services/systemMetrics.ts
+++ b/src/services/systemMetrics.ts
@@ -64,33 +64,50 @@ export type DiskUsage = {
 };
 
 export const getDiskUsage = async (): Promise<DiskUsage[]> => {
-  const { stdout } = await execAsync('df -Pk --output=source,fstype,size,used,avail,pcent,target');
-  const lines = stdout.trim().split('\n').slice(1);
+  try {
+    const { stdout } = await execAsync('df -Pk --output=source,fstype,size,used,avail,pcent,target');
+    const lines = stdout.trim().split('\n').slice(1);
 
-  return lines
-    .map(line => line.trim().split(/\s+/))
-    .filter(parts => parts.length >= 7)
-    .map(parts => {
-      const [filesystem, type, size, used, avail, pcent, ...mount] = parts;
-      const mountpoint = mount.join(' ');
-      return {
-        filesystem,
-        type,
-        sizeKB: Number(size),
-        usedKB: Number(used),
-        availKB: Number(avail),
-        usedPercent: Number((pcent || '0').replace('%', '')),
-        mountpoint
-      };
-    });
+    return lines
+      .map(line => line.trim().split(/\s+/))
+      .filter(parts => parts.length >= 7)
+      .map(parts => {
+        const [filesystem, type, size, used, avail, pcent, ...mount] = parts;
+        const mountpoint = mount.join(' ');
+        return {
+          filesystem,
+          type,
+          sizeKB: Number(size),
+          usedKB: Number(used),
+          availKB: Number(avail),
+          usedPercent: Number((pcent || '0').replace('%', '')),
+          mountpoint
+        };
+      });
+  } catch (error) {
+    console.error('Failed to read disk usage', error);
+    return [];
+  }
 };
 
 export const getSystemResources = async () => {
-  const [cpu, memory, disks] = await Promise.all([
-    getCpuUsage(),
-    Promise.resolve(getMemoryUsage()),
-    getDiskUsage()
-  ]);
+  let cpu;
+  try {
+    cpu = await getCpuUsage();
+  } catch (error) {
+    console.error('Failed to read CPU usage', error);
+    cpu = { cores: os.cpus().length, usagePercent: 0, loadAverage: [] };
+  }
+
+  let memory;
+  try {
+    memory = getMemoryUsage();
+  } catch (error) {
+    console.error('Failed to read memory usage', error);
+    memory = { total: 0, free: 0, used: 0, usedPercent: 0 };
+  }
+
+  const disks = await getDiskUsage();
 
   return { cpu, memory, disks };
 };

--- a/src/services/systemMetrics.ts
+++ b/src/services/systemMetrics.ts
@@ -1,0 +1,96 @@
+import os from 'os';
+import { promisify } from 'util';
+import { exec } from 'child_process';
+
+const execAsync = promisify(exec);
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+type CpuSnapshot = { idle: number; total: number };
+
+const captureCpu = (): CpuSnapshot => {
+  const cpus = os.cpus();
+  const aggregate = cpus.reduce(
+    (acc, cpu) => {
+      const times = cpu.times;
+      const total = times.user + times.nice + times.sys + times.idle + times.irq;
+      acc.idle += times.idle;
+      acc.total += total;
+      return acc;
+    },
+    { idle: 0, total: 0 }
+  );
+  return aggregate;
+};
+
+export const getCpuUsage = async (sampleMs: number = 200) => {
+  const start = captureCpu();
+  await sleep(sampleMs);
+  const end = captureCpu();
+
+  const idleDiff = end.idle - start.idle;
+  const totalDiff = end.total - start.total;
+  const usage = totalDiff > 0 ? (1 - idleDiff / totalDiff) * 100 : 0;
+
+  return {
+    cores: os.cpus().length,
+    usagePercent: Math.min(100, Math.max(0, Number(usage.toFixed(2)))),
+    loadAverage: os.loadavg()
+  };
+};
+
+export const getMemoryUsage = () => {
+  const total = os.totalmem();
+  const free = os.freemem();
+  const used = total - free;
+  const usedPercent = total > 0 ? Number(((used / total) * 100).toFixed(2)) : 0;
+
+  return {
+    total,
+    free,
+    used,
+    usedPercent
+  };
+};
+
+export type DiskUsage = {
+  filesystem: string;
+  type?: string;
+  sizeKB: number;
+  usedKB: number;
+  availKB: number;
+  usedPercent: number;
+  mountpoint: string;
+};
+
+export const getDiskUsage = async (): Promise<DiskUsage[]> => {
+  const { stdout } = await execAsync('df -Pk --output=source,fstype,size,used,avail,pcent,target');
+  const lines = stdout.trim().split('\n').slice(1);
+
+  return lines
+    .map(line => line.trim().split(/\s+/))
+    .filter(parts => parts.length >= 7)
+    .map(parts => {
+      const [filesystem, type, size, used, avail, pcent, ...mount] = parts;
+      const mountpoint = mount.join(' ');
+      return {
+        filesystem,
+        type,
+        sizeKB: Number(size),
+        usedKB: Number(used),
+        availKB: Number(avail),
+        usedPercent: Number((pcent || '0').replace('%', '')),
+        mountpoint
+      };
+    });
+};
+
+export const getSystemResources = async () => {
+  const [cpu, memory, disks] = await Promise.all([
+    getCpuUsage(),
+    Promise.resolve(getMemoryUsage()),
+    getDiskUsage()
+  ]);
+
+  return { cpu, memory, disks };
+};

--- a/src/services/systemMetrics.ts
+++ b/src/services/systemMetrics.ts
@@ -34,8 +34,7 @@ export const getCpuUsage = async (sampleMs: number = 200) => {
 
   return {
     cores: os.cpus().length,
-    usagePercent: Math.min(100, Math.max(0, Number(usage.toFixed(2)))),
-    loadAverage: os.loadavg()
+    usagePercent: Math.min(100, Math.max(0, Number(usage.toFixed(2))))
   };
 };
 
@@ -65,7 +64,7 @@ export type DiskUsage = {
 
 export const getDiskUsage = async (): Promise<DiskUsage[]> => {
   try {
-    const { stdout } = await execAsync('df -Pk --output=source,fstype,size,used,avail,pcent,target');
+    const { stdout } = await execAsync('df -kPT 2>/dev/null');
     const lines = stdout.trim().split('\n').slice(1);
 
     return lines
@@ -96,7 +95,7 @@ export const getSystemResources = async () => {
     cpu = await getCpuUsage();
   } catch (error) {
     console.error('Failed to read CPU usage', error);
-    cpu = { cores: os.cpus().length, usagePercent: 0, loadAverage: [] };
+    cpu = { cores: os.cpus().length, usagePercent: 0 };
   }
 
   let memory;


### PR DESCRIPTION
## Summary
- add Linux resource collection helpers and Next.js API routes for CPU, memory, disk, and combined system metrics
- introduce a base support system resources page with CPU/memory/disk visuals plus VM and container instance overviews
- extend base support menu metadata and sidebar handling to surface the new page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e7c6a9cc8320865f2c3e6c68114c)