### PR TITLE
Add validation to prevent Chinese names in instance modals

### DIFF
--- a/src/components/scenario/CreateContainerModal.tsx
+++ b/src/components/scenario/CreateContainerModal.tsx
@@ -20,6 +20,7 @@ import { useAuth } from '@/hooks/useAuth';
 import {customFetch} from "@/utils/fetch.ts";
 
 const API_BASE = '/back/api';
+const chineseCharPattern = /[\u4e00-\u9fa5]/;
 
 interface CreateContainerModalProps {
   open: boolean;
@@ -41,6 +42,7 @@ export default function CreateContainerModal({ open, onClose, onCreated, fixedIm
   const [volumes, setVolumes] = useState<{ hostPath: string; containerPath: string }[]>([]);
   const [envs, setEnvs] = useState<{ key: string; value: string }[]>([]);
   const [cmd, setCmd] = useState('');
+  const [errors, setErrors] = useState<{ name?: string }>({});
 
   useEffect(() => {
     if (!open) return;
@@ -61,6 +63,7 @@ export default function CreateContainerModal({ open, onClose, onCreated, fixedIm
     setVolumes([]);
     setEnvs([]);
     setCmd('');
+    setErrors({});
   };
 
   const handleClose = () => {
@@ -88,6 +91,13 @@ export default function CreateContainerModal({ open, onClose, onCreated, fixedIm
 
   const handleSubmit = async () => {
     if (!user || !image) return;
+
+    const newErrors: { name?: string } = {};
+    if (name && chineseCharPattern.test(name)) {
+      newErrors.name = '容器名称不能包含中文字符';
+    }
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
     await customFetch(`${API_BASE}/containers`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -123,7 +133,18 @@ export default function CreateContainerModal({ open, onClose, onCreated, fixedIm
               renderInput={(params) => <TextField {...params} label="镜像" />}
             />
           )}
-          <TextField label="容器名称" value={name} onChange={e => setName(e.target.value)} fullWidth />
+          <TextField
+            label="容器名称"
+            value={name}
+            onChange={e => {
+              const value = e.target.value;
+              setName(value);
+              setErrors(prev => ({ ...prev, name: chineseCharPattern.test(value) ? '容器名称不能包含中文字符' : undefined }));
+            }}
+            fullWidth
+            error={!!errors.name}
+            helperText={errors.name}
+          />
           <Box>
             <Typography variant="subtitle2" gutterBottom>端口映射</Typography>
             {ports.map((p, idx) => (

--- a/src/components/scenario/topology/NodeEditModal.tsx
+++ b/src/components/scenario/topology/NodeEditModal.tsx
@@ -38,6 +38,7 @@ interface TeamOption {
 
 const COMPUTE_RESOURCE_TYPES = ['容器'];
 const BRIDGE_TYPES = ['NAT网桥'];
+const chineseCharPattern = /[\u4e00-\u9fa5]/;
 
 interface NodeEditModalProps {
   isOpen: boolean;
@@ -161,8 +162,14 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ isOpen, onClose, node, on
   }, [teams, selectedTeamId, legacyTeamLabel]);
 
   const validate = (): boolean => {
-    // 您可以根据需要添加对 iptables 规则的验证
-    return true;
+    const newErrors: { [key: string]: string } = {};
+
+    if (node?.type === 'container' && chineseCharPattern.test(label)) {
+      newErrors.label = '节点名称不能包含中文字符';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
   };
   
   // --- 端口映射处理函数 (保持不变) ---
@@ -252,7 +259,23 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ isOpen, onClose, node, on
         <DialogTitle>编辑节点: {node?.label}</DialogTitle>
         <DialogContent dividers>
           <Stack spacing={3} sx={{ mt: 1 }}>
-            <TextField label="节点名称 (标签)" value={label} onChange={(e) => setLabel(e.target.value)} required fullWidth disabled={disabled} />
+            <TextField
+              label="节点名称 (标签)"
+              value={label}
+              onChange={(e) => {
+                const value = e.target.value;
+                setLabel(value);
+                setErrors(prev => ({
+                  ...prev,
+                  label: node?.type === 'container' && chineseCharPattern.test(value) ? '节点名称不能包含中文字符' : undefined,
+                }));
+              }}
+              required
+              fullWidth
+              disabled={disabled}
+              error={!!_errors.label}
+              helperText={_errors.label}
+            />
             <TextField label="设备类型/名称" value={deviceName} fullWidth disabled />
             <FormControl fullWidth size="small" disabled={disabled}>
               <InputLabel>队伍分配</InputLabel>

--- a/src/components/scenario/topology/VirtualMachineEditModal.tsx
+++ b/src/components/scenario/topology/VirtualMachineEditModal.tsx
@@ -43,6 +43,8 @@ interface VirtualMachineEditModalProps {
   isEditable?: boolean;
 }
 
+const chineseCharPattern = /[\u4e00-\u9fa5]/;
+
 const VirtualMachineEditModal: React.FC<VirtualMachineEditModalProps> = ({ isOpen, onClose, node, onSave, isEditable = true }) => {
   // --- 状态管理 ---
   const [label, setLabel] = useState('');
@@ -153,6 +155,7 @@ const VirtualMachineEditModal: React.FC<VirtualMachineEditModalProps> = ({ isOpe
   const validate = (): boolean => {
     const newErrors: { [key: string]: string } = {};
     if (!label.trim()) newErrors.label = '节点名称不能为空';
+    else if (node?.type === 'virtual_machine' && chineseCharPattern.test(label)) newErrors.label = '节点名称不能包含中文字符';
     if (!baseImage) newErrors.baseImage = '必须选择一个基础镜像';
     if (memory && isNaN(Number(memory))) newErrors.memory = '内存大小必须是数字';
     if (cpu && isNaN(Number(cpu))) newErrors.cpu = 'CPU核心数必须是数字';
@@ -212,7 +215,18 @@ const VirtualMachineEditModal: React.FC<VirtualMachineEditModalProps> = ({ isOpe
             <TextField
               label="节点名称 (标签)"
               value={label}
-              onChange={(e) => setLabel(e.target.value)}
+              onChange={(e) => {
+                const value = e.target.value;
+                setLabel(value);
+                setErrors(prev => ({
+                  ...prev,
+                  label: !value.trim()
+                    ? '节点名称不能为空'
+                    : node?.type === 'virtual_machine' && chineseCharPattern.test(value)
+                      ? '节点名称不能包含中文字符'
+                      : undefined,
+                }));
+              }}
               required
               fullWidth
               error={!!_errors.label}

--- a/src/components/vm/CreateVmModal.tsx
+++ b/src/components/vm/CreateVmModal.tsx
@@ -14,6 +14,8 @@ import {
 import Autocomplete from '@mui/material/Autocomplete';
 import {customFetch} from "@/utils/fetch.ts";
 
+const chineseCharPattern = /[\u4e00-\u9fa5]/;
+
 interface VmImage {
   name: string;
   path: string;
@@ -34,6 +36,7 @@ export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: 
     ip: "",
     is_target: false
   });
+  const [errors, setErrors] = useState<{ vm_name?: string }>({});
 
   useEffect(() => {
     if (!open) return;
@@ -55,6 +58,7 @@ export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: 
       ip: "",
       is_target: false
     });
+    setErrors({});
   };
 
   const handleClose = () => {
@@ -63,6 +67,13 @@ export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: 
   };
 
   const handleSubmit = async () => {
+    const newErrors: { vm_name?: string } = {};
+    if (form.vm_name && chineseCharPattern.test(form.vm_name)) {
+      newErrors.vm_name = "实例名称不能包含中文字符";
+    }
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
     await customFetch("/back/api/vms/create", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -91,7 +102,14 @@ export default function CreateVmModal({ open, onClose, onCreated, fixedImage }: 
             />
           )}
           <TextField label="实例名称" value={form.vm_name}
-            onChange={e => setForm(f => ({ ...f, vm_name: e.target.value }))} fullWidth />
+            onChange={e => {
+              const value = e.target.value;
+              setForm(f => ({ ...f, vm_name: value }));
+              setErrors(prev => ({ ...prev, vm_name: chineseCharPattern.test(value) ? "实例名称不能包含中文字符" : undefined }));
+            }}
+            error={!!errors.vm_name}
+            helperText={errors.vm_name}
+            fullWidth />
           <TextField label="IP 地址" value={form.ip}
             onChange={e => setForm(f => ({ ...f, ip: e.target.value }))} fullWidth />
           <FormControlLabel


### PR DESCRIPTION
## Summary
- add client-side validation to container creation modals to prevent Chinese characters in names
- apply the same Chinese character checks to VM creation and scenario node edit dialogs
- surface validation feedback to users and reset related error state when closing dialogs

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d2504b7608320bba49915be8bde8f)