### PR TITLE
docs: add remote access proxy integration specification

### DIFF
--- a/软件设计说明书-实例管理模块.md
+++ b/软件设计说明书-实例管理模块.md
@@ -1,0 +1,405 @@
+# 软件设计说明书（实例管理模块）
+
+## 1. 模块概述与范围
+
+实例管理模块覆盖容器实例、虚拟机实例与场景实例的全生命周期管理，包括实例列表展示、检索筛选、状态与资源信息展示、启动/暂停/停止/删除等生命周期操作，以及场景实例级别的资源拓扑与细节查看。该模块以“实例”为核心对象，将运行态资源与场景配置、容器/虚拟机的状态关联展示，使管理员与教学场景维护人员可以在统一入口完成实例监控与处置。 
+
+本说明书**不包含**以下内容：
+
+1. 虚拟机的 VNC/Guacamole 连接能力与相关接口。
+2. Docker 容器的 Terminal/终端连接能力与权限判断流程。
+
+上述功能虽在代码库中存在，但不在本模块当前文档的范围内。 
+
+## 2. 代码范围与文件清单
+
+### 2.1 前端页面与组件
+
+- 容器实例管理页面：`src/app/scenario/instances/page.tsx`
+- 虚拟机实例管理页面：`src/app/scenario/vm-instances/page.tsx`
+- 场景实例管理页面：`src/app/scenario/sceneinstances/page.tsx`
+- 场景实例容器/虚拟机/交换机标签页：
+  - `src/app/scenario/sceneinstances/ContainerInstancesTab.tsx`
+  - `src/app/scenario/sceneinstances/VmInstancesTab.tsx`
+  - `src/app/scenario/sceneinstances/SwitchInstancesTab.tsx`
+- 实例详情与辅助视图：
+  - `src/components/scenario/InstanceDetailsModal.tsx`
+  - `src/components/scenario/ContainerLogsModal.tsx`
+  - `src/components/scenario/ContainerInspectModal.tsx`
+  - `src/components/scenario/BindMountsModal.tsx`
+  - `src/app/scenario/sceneinstances/InstanceDetailsDialog.tsx`
+  - `src/app/scenario/sceneinstances/InstanceTopologyDialog.tsx`
+  - `src/app/scenario/sceneinstances/IptablesDialog.tsx`
+- 虚拟机快照管理面板：`src/components/vm/SnapshotsPanel.tsx`
+- 创建实例对话框：
+  - `src/components/scenario/CreateContainerModal.tsx`
+  - `src/components/vm/CreateVmModal.tsx`
+
+### 2.2 Next.js API（前端侧后端）
+
+- 容器实例列表/增删改：`src/app/api/instances/route.ts`
+- 容器实例创建：`src/app/api/containers/route.ts`
+- 容器实例动作/详情：`src/app/api/containers/[id]/route.ts`
+
+### 2.3 业务服务与数据层
+
+- Docker 实例信息读取/控制：`src/lib/docker.ts`
+- Prisma 实例数据访问：`src/lib/db/queries.ts`
+- Prisma 数据模型：`src/prisma/schema.prisma`
+- 运行实例类型定义：`src/types.ts`
+- 状态展示翻译：`src/constants.ts`
+
+### 2.4 Laravel 后端（/back/api）
+
+- 容器实例列表：`back/app/Http/Controllers/Docker/InstancesController.php`
+- 容器实例操作：`back/app/Http/Controllers/Docker/ContainersController.php`
+- 虚拟机实例管理：`back/app/Http/Controllers/Vm/VmController.php`
+- 场景实例管理：`back/app/Http/Controllers/scenario/InstanceController.php`
+- 容器与虚拟机实例模型：
+  - `back/app/Models/scenario/SceneInstance.php`
+  - `back/app/Models/scenario/SceneContainerInstance.php`
+  - `back/app/Models/scenario/SceneVmInstance.php`
+  - `back/app/Models/scenario/SceneSwitchInstance.php`
+- API 路由汇总：`back/routes/api.php`
+
+## 3. 功能设计（详细功能点）
+
+### 3.1 容器实例管理
+
+容器实例管理页面提供容器运行态列表展示、关键词搜索、列展示控制与周期性刷新能力，并支持容器生命周期操作（启动、暂停、停止、删除）。在列表中，容器的运行状态、镜像名称、端口映射、资源占用（CPU/内存）与场景关联信息可直接可视化展示，并且通过“更多操作”菜单可以查看容器日志、容器 Inspect 详情与挂载点信息。对于需要快速拉起服务的场景，还提供“创建实例”入口以指定镜像与端口映射创建容器。 
+
+具体功能点：
+
+1. 实例列表展示：显示容器名称、状态、IP、镜像名、端口、CPU/内存、运行时间、场景关联信息。
+2. 搜索与筛选：支持按名称、ID、镜像名、IP 搜索；可过滤只显示运行中的容器。
+3. 生命周期操作：启动、暂停、停止、删除容器实例。
+4. 详情与运维视图：查看日志、Inspect 详情与挂载点信息。
+5. 刷新与轮询：手动刷新与定时轮询（5 秒）结合。
+6. 创建容器实例：通过创建对话框提交镜像、端口映射等参数。
+
+### 3.2 虚拟机实例管理
+
+虚拟机实例管理页面以虚拟机为对象，展示虚拟机名称、运行状态、主机节点、CPU/内存、IP 与 UUID 等信息，并提供生命周期操作（启动、暂停、重启、强制关机、删除）。此外，页面内置快照管理入口，可对虚拟机进行快照创建、恢复与删除。该页面使用 SWR 进行智能轮询，以在虚拟机状态变化时保持及时刷新。 
+
+具体功能点：
+
+1. 实例列表展示：展示虚拟机名称、状态、主机节点、CPU/内存、IP、UUID。
+2. 搜索与筛选：支持按名称搜索；可过滤只显示运行中的虚拟机。
+3. 生命周期操作：启动、暂停/恢复、重启、强制关机、删除虚拟机实例。
+4. 快照管理：创建快照、恢复快照、删除快照，树形展示快照层级。
+5. 智能轮询：根据状态变化调整轮询周期，提高操作反馈及时性。
+
+### 3.3 场景实例管理
+
+场景实例管理页面面向场景级资源集合，提供实例列表、状态与运行时长展示，并支持停止与删除场景实例。页面还可打开实例详情弹窗与拓扑视图，查看场景配置及节点拓扑信息，同时提供 iptables 管理入口以便进行场景内网络规则的运维查看与调整。 
+
+具体功能点：
+
+1. 场景实例列表：展示场景名称、创建用户、运行时长、状态与节点信息。
+2. 搜索与排序：支持按场景名称与用户名搜索、按运行时长/状态排序。
+3. 实例操作：停止场景实例（拆卸资源）、删除场景实例（清理资源）。
+4. 详情与拓扑：查看实例详情与拓扑结构（基于场景配置）。
+5. iptables 管理：查看或管理场景实例的网络规则。 
+
+## 4. 数据结构设计
+
+### 4.1 容器实例表（Instance）
+
+**表-字段清单：Instance（Prisma/SQLite）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| id | String | 主键 | 容器实例唯一 ID。 |
+| name | String | 非空 | 实例名称。 |
+| type | String | 非空 | 实例类型（如 container）。 |
+| status | String | 非空 | 运行状态。 |
+| ip_address | String | 非空 | IP 地址或端口映射信息。 |
+| image_name | String | 非空 | 镜像名称。 |
+| cpu_usage | String | 非空 | CPU 使用率字符串。 |
+| memory_usage | String | 非空 | 内存使用率字符串。 |
+| disk_usage | String | 非空 | 磁盘使用信息。 |
+| uptime | String | 非空 | 运行时长。 |
+| node_id | String | 可空 | 所属节点。 |
+| created_at | DateTime | 非空 | 创建时间。 |
+
+### 4.2 场景实例表（c_scene_instances）
+
+**表-字段清单：c_scene_instances（场景实例）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| c_scene_instances_id | String | 主键 | 场景实例 ID。 |
+| c_config_id | String/Int | 可空 | 场景配置 ID。 |
+| c_username | String | 可空 | 创建用户。 |
+| c_status | String | 可空 | 场景实例状态。 |
+| c_scene_config | JSON | 可空 | 场景配置快照。 |
+| c_hostname | String | 可空 | 所属主机名。 |
+| c_runtime | DateTime | 自动 | 创建时间（时间戳字段）。 |
+
+### 4.3 场景容器实例表（c_scene_container_instances）
+
+**表-字段清单：c_scene_container_instances**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| c_container_id | String | 主键 | 容器实例 ID。 |
+| c_scene_instances_id | String | 外键 | 关联场景实例 ID。 |
+| c_flag | String | 可空 | 靶标标识或标记。 |
+| c_ip | String | 可空 | 容器 IP。 |
+| c_container_name | String | 可空 | 容器名称。 |
+| c_team_id | String | 可空 | 归属队伍 ID。 |
+
+### 4.4 场景虚拟机实例表（c_scene_vm_instances）
+
+**表-字段清单：c_scene_vm_instances**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| c_vm_id | Int | 主键 | 虚拟机实例记录 ID。 |
+| c_vm_name | String | 非空 | 虚拟机名称。 |
+| c_scene_instances_id | String | 外键 | 关联场景实例 ID。 |
+| c_ip | String | 可空 | 虚拟机 IP。 |
+| c_flag | String | 可空 | 靶标标识或标记。 |
+| c_team_id | String | 可空 | 归属队伍 ID。 |
+
+### 4.5 场景交换机实例表（c_scene_switch_instances）
+
+**表-字段清单：c_scene_switch_instances**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| c_switch_name | String | 非空 | 交换机名称。 |
+| c_scene_instances_id | String | 外键 | 关联场景实例 ID。 |
+
+### 4.6 运行实例前端结构（RunningInstance）
+
+**表-字段清单：RunningInstance（前端类型）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| id | String | 非空 | 实例唯一 ID。 |
+| name | String | 非空 | 实例名称。 |
+| type | String | 非空 | 实例类型（container/vm/交换机等）。 |
+| status | String | 非空 | 运行状态。 |
+| ipAddress | String | 可空 | IP 地址。 |
+| scene_instance_id | String | 可空 | 关联场景实例 ID。 |
+| scene_name | String | 可空 | 关联场景名称。 |
+| ports | String | 可空 | 端口映射信息。 |
+| imageName | String | 非空 | 镜像名称。 |
+| cpuUsage | String | 非空 | CPU 使用率。 |
+| memoryUsage | String | 非空 | 内存使用率。 |
+| diskUsage | String | 可空 | 磁盘使用情况。 |
+| uptime | String | 非空 | 运行时间。 |
+| nodeId | String | 可空 | 节点信息。 |
+| createdAt | String | 非空 | 创建时间（ISO）。 |
+
+## 5. 类设计与结构关系
+
+### 5.1 类图（Mermaid）
+
+```mermaid
+classDiagram
+    class ContainerInstancesPage {
+        +fetchInstances()
+        +handleStartInstance()
+        +handleStopInstance()
+        +handlePauseInstance()
+        +handleDeleteInstance()
+    }
+    class VmInstancesPage {
+        +handleLifecycle()
+        +handleDelete()
+        +openSnapshots()
+    }
+    class ScenarioInstancesPage {
+        +fetchInstances()
+        +handleStopInstance()
+        +handleDeleteInstance()
+        +handleViewTopology()
+    }
+    class ContainersController {
+        +create()
+        +action()
+        +get()
+        +inspect()
+        +info()
+    }
+    class InstancesController {
+        +index()
+        +destroy()
+    }
+    class VmController {
+        +listVms()
+        +manageVmLifecycle()
+        +listVmSnapshots()
+        +createVmSnapshot()
+        +revertVmSnapshot()
+        +deleteVmSnapshot()
+    }
+    class SceneInstanceController {
+        +index()
+        +show()
+        +getDetails()
+        +tearDownResources()
+        +destroy()
+    }
+    class DockerService {
+        +listContainers()
+        +containerStats()
+        +startContainer()
+        +stopContainer()
+    }
+
+    ContainerInstancesPage --> InstancesController
+    ContainerInstancesPage --> ContainersController
+    VmInstancesPage --> VmController
+    ScenarioInstancesPage --> SceneInstanceController
+    InstancesController --> DockerService
+    ContainersController --> DockerService
+```
+
+### 5.2 结构说明
+
+实例管理模块的核心页面分为容器实例、虚拟机实例与场景实例三类入口。容器实例通过 DockerService 获取运行态容器与资源占用信息，同时配合场景实例数据库表补充 IP、场景名称等信息；虚拟机实例通过 VmController 封装 virsh 调用，提供生命周期与快照管理；场景实例管理通过 InstanceController 统一查询、停止与删除场景实例，并在前端提供拓扑与详情查看。前端通过 `customFetch` 统一携带认证信息，并使用表格组件完成多维度筛选与分页展示。 
+
+## 6. 关键流程设计（典型业务场景）
+
+### 6.1 典型场景一：容器实例列表加载与刷新
+
+**流程说明**：进入容器实例页面后，前端调用 `/back/api/instances` 拉取容器实例列表。后端从 Docker 容器列表中构建结果，并通过关联场景实例表补充场景信息和 IP。前端每 5 秒轮询一次，同时支持手动刷新。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ContainerInstancesPage
+    participant API as /back/api/instances
+    participant Svc as DockerService
+    UI->>API: GET /back/api/instances
+    API->>Svc: listContainers()
+    Svc-->>API: 容器列表与状态
+    API-->>UI: 运行实例数据
+    UI->>UI: 渲染表格与筛选
+```
+
+### 6.2 典型场景二：容器实例生命周期操作
+
+**流程说明**：用户在容器实例表格中选择启动/暂停/停止/删除操作后，前端弹出确认框，确认后调用 `/back/api/containers/{id}?action=...` 执行动作；删除时还会调用 `/back/api/instances?id=...` 清理本地实例记录。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ContainerInstancesPage
+    participant API as /back/api/containers/{id}
+    participant DBAPI as /back/api/instances
+    participant Svc as DockerService
+    UI->>API: POST ?action=start|pause|stop|delete
+    API->>Svc: start/pause/stop/remove
+    Svc-->>API: ok
+    API-->>UI: ok
+    UI->>DBAPI: DELETE /back/api/instances?id=...
+    DBAPI-->>UI: ok
+```
+
+### 6.3 典型场景三：容器实例日志/详情/挂载点查看
+
+**流程说明**：通过“更多操作”菜单触发日志与挂载点查看时，前端调用 `/api/containers/{id}?action=logs` 与 `/api/containers/{id}?action=binds`；Inspect 详情则通过 `/back/api/containers/{id}/inspect` 获取。后端透传 Docker Inspect/Stats 结果并返回 JSON，前端在弹窗中展示。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ContainerInstancesPage
+    participant API as /api/containers/{id}
+    participant Svc as DockerService
+    UI->>API: GET ?action=logs|binds
+    API->>Svc: containerLogs() / listBindMounts()
+    Svc-->>API: data
+    API-->>UI: JSON payload
+```
+
+### 6.4 典型场景四：虚拟机实例生命周期管理
+
+**流程说明**：虚拟机实例页面通过 `/back/api/vms` 拉取列表，在操作时调用 `/back/api/vms/{vm_id}/actions/{action}` 执行状态切换。后端使用 virsh 执行命令并等待状态完成后返回。 
+
+```mermaid
+sequenceDiagram
+    participant UI as VmInstancesPage
+    participant API as /back/api/vms/{vm_id}/actions/{action}
+    participant Virsh as virsh
+    UI->>API: POST action=start/pause/resume/reboot/force-off
+    API->>Virsh: runVirsh(command)
+    Virsh-->>API: result
+    API-->>UI: state updated
+```
+
+### 6.5 典型场景五：虚拟机快照管理
+
+**流程说明**：用户在快照面板创建、恢复或删除快照时，前端分别调用 `/back/api/vms/{vm_id}/snapshots`、`/back/api/vms/{vm_id}/snapshots/{id}/revert` 与 `/back/api/vms/{vm_id}/snapshots/{id}`，后端调用 virsh snapshot 系列命令并返回结果。 
+
+```mermaid
+sequenceDiagram
+    participant UI as SnapshotsPanel
+    participant API as /back/api/vms/{vm_id}/snapshots
+    participant Virsh as virsh
+    UI->>API: POST create snapshot
+    API->>Virsh: snapshot-create-as
+    Virsh-->>API: ok
+    API-->>UI: refresh snapshots
+    UI->>API: POST snapshots/{id}/revert
+    API->>Virsh: snapshot-revert
+    Virsh-->>API: ok
+    API-->>UI: ok
+```
+
+### 6.6 典型场景六：场景实例停止与删除
+
+**流程说明**：场景实例页面支持停止与删除操作。停止操作调用 `/back/api/scenariosinstances/{id}/teardown`，后端拆卸场景资源；删除操作调用 `/back/api/scenariosinstances/{id}` 清理实例记录。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ScenarioInstancesPage
+    participant API as /back/api/scenariosinstances/{id}
+    UI->>API: POST /teardown
+    API-->>UI: ok
+    UI->>API: DELETE
+    API-->>UI: ok
+```
+
+## 7. 接口实现要点
+
+**接口清单（实例管理模块）**
+
+| 路径 | 方法 | 功能 | 备注 |
+| --- | --- | --- | --- |
+| `/back/api/instances` | GET | 获取容器实例列表 | Docker 列表 + 场景信息聚合。 |
+| `/back/api/instances` | DELETE | 删除实例记录 | 删除本地实例记录。 |
+| `/api/instances` | GET | 获取容器实例列表 | Next.js 接口（基于 dockerode）。 |
+| `/api/instances` | POST | 新建实例记录 | 写入实例数据表。 |
+| `/api/instances` | PUT | 更新实例记录 | 更新实例数据表。 |
+| `/api/instances` | DELETE | 删除实例记录 | 删除实例数据表记录。 |
+| `/back/api/containers` | POST | 创建容器实例 | 创建并启动容器。 |
+| `/back/api/containers/{id}` | POST | 容器生命周期操作 | start/stop/pause/unpause/delete。 |
+| `/api/containers` | POST | 创建容器实例 | Next.js 接口，创建并记录实例。 |
+| `/api/containers/{id}` | GET | 容器日志/挂载点 | 通过 action=logs/binds 查询。 |
+| `/api/containers/{id}` | POST | 容器生命周期操作 | start/stop/pause/unpause/delete。 |
+| `/back/api/containers/{id}/inspect` | GET | 容器 Inspect | 返回 Docker Inspect。 |
+| `/back/api/containers/{id}/info` | GET | 容器信息 | 聚合状态与资源占用。 |
+| `/back/api/vms` | GET | 获取虚拟机实例列表 | virsh list + DB 补充。 |
+| `/back/api/vms/{vm_id}` | GET | 获取虚拟机详情 | 运行态与资源信息。 |
+| `/back/api/vms/{vm_id}` | DELETE | 删除虚拟机 | 删除实例及存储。 |
+| `/back/api/vms/{vm_id}/actions/{action}` | POST | 虚拟机生命周期操作 | start/pause/resume/reboot/force-off。 |
+| `/back/api/vms/{vm_id}/snapshots` | GET | 获取快照列表 | 返回快照树结构数据。 |
+| `/back/api/vms/{vm_id}/snapshots` | POST | 创建快照 | 创建并返回快照信息。 |
+| `/back/api/vms/{vm_id}/snapshots/{snapshot_id}/revert` | POST | 恢复快照 | 虚拟机状态回滚。 |
+| `/back/api/vms/{vm_id}/snapshots/{snapshot_id}` | DELETE | 删除快照 | 删除指定快照。 |
+| `/back/api/scenariosinstances` | GET | 获取场景实例列表 | 供场景实例管理页面使用。 |
+| `/back/api/scenariosinstances/{id}` | GET | 获取场景实例详情 | 支持详情弹窗。 |
+| `/back/api/scenariosinstances/{id}` | DELETE | 删除场景实例 | 清理实例与关联资源。 |
+| `/back/api/scenariosinstances/{id}/details` | GET | 获取场景实例详情信息 | 展示拓扑/节点细节。 |
+| `/back/api/scenariosinstances/{id}/teardown` | POST | 停止场景实例 | 拆卸场景资源。 |
+| `/back/api/scenariosinstances/iptables` | GET | 获取 iptables 信息 | 场景实例网络规则查看。 |
+| `/back/api/scenariosinstances/iptables` | DELETE | 删除 iptables 规则 | 场景实例网络规则维护。 |
+
+## 8. 设计要点与边界说明
+
+1. **多源数据聚合**：容器实例信息来自 Docker 运行态，虚拟机实例来自 virsh，场景实例来自业务数据库，三类实例统一在前端以表格方式展示。
+2. **状态驱动操作**：容器与虚拟机操作均以状态为判定条件，避免重复操作造成状态异常。
+3. **高频刷新与一致性**：容器实例使用固定轮询，虚拟机实例使用智能轮询，保证资源状态与操作反馈及时。
+4. **快照为扩展能力**：虚拟机快照管理作为实例管理的扩展能力，但不涉及 VNC/终端链接。
+5. **范围限制**：VNC/Guacamole 与容器终端访问不在本文范围内；相关接口未在接口清单中描述。

--- a/软件设计说明书-远程访问代理集成模块.md
+++ b/软件设计说明书-远程访问代理集成模块.md
@@ -1,0 +1,232 @@
+# 软件设计说明书（远程访问代理集成模块）
+
+## 1. 模块概述与范围
+
+远程访问代理集成模块负责将平台内的“虚拟机 VNC 访问”与“容器终端访问”统一接入到 Web UI。该模块通过 Guacamole Lite 服务与 WebSocket 代理实现虚拟机远程桌面/控制台连接，并通过 Socket.IO + pty 为容器提供交互式终端。前端侧负责发起连接、弹窗渲染与输入输出交互，后端侧负责权限校验与连接参数的生成与代理转发。 
+
+本文档覆盖的能力范围包括：
+
+- 虚拟机 VNC 链接路径（Guacamole 代理与连接参数获取）。
+- 容器 Terminal 的打开与权限校验流程。
+- WebSocket/代理端点与关键的安全边界。 
+
+不包含内容：
+
+- 实例管理模块中的其它生命周期操作（启动、停止等）。
+- 镜像管理与场景管理相关流程。
+
+## 2. 代码范围与文件清单
+
+### 2.1 前端页面与组件
+
+- 虚拟机实例页面中的 VNC 入口：`src/app/scenario/vm-instances/page.tsx`
+- 场景实例的 VM/VNC 入口：`src/app/scenario/sceneinstances/VmInstancesTab.tsx`
+- 学习场景 VM/VNC 入口：`src/components/learning/sceneinstances/VmInstancesTab.tsx`
+- 远程终端上下文：`src/contexts/ExecTerminalContext.tsx`
+- 终端弹窗组件：`src/components/scenario/ExecTerminalModal.tsx`
+- Guacamole 弹窗组件：`src/components/vm/GuacModal.tsx`
+- Guacamole 页面封装：`src/app/guacamole/route.ts`
+
+### 2.2 Next.js API
+
+- Guacamole Token 生成：`src/app/api/token-guac/route.ts`
+
+### 2.3 Node 服务与代理
+
+- 统一服务入口与代理：`src/server.js`
+- Guacamole 静态入口 HTML：`src/public/index.html`
+
+### 2.4 Laravel 后端（/back/api）
+
+- VM 连接信息：`back/app/Http/Controllers/Vm/VmController.php`
+- 容器终端权限接口：`back/app/Http/Controllers/Docker/ContainersController.php`
+- API 路由：`back/routes/api.php`
+
+## 3. 功能设计（详细功能点）
+
+### 3.1 虚拟机 VNC 远程访问
+
+虚拟机 VNC 访问功能在前端通过“VNC 控制台”入口触发。用户在虚拟机列表中点击后，页面调用后端 `/back/api/vms/{vm_name}/guac`（或带 authority 的版本）获取连接参数，包括 host 与 vnc 端口等信息，随后通过隐藏表单跳转到 `/guacamole` 路由生成内嵌 iframe 页面。该 iframe 加载 `public/index.html` 并建立 Guacamole WebSocket 通道连接 `/connect-guac`，最终实现 VNC 控制台在浏览器内打开。 
+
+关键功能点：
+
+1. 连接参数获取：通过 `/back/api/vms/{vm_name}/guac` 返回 SSH/RDP/VNC 端口信息（本文仅强调 VNC）。
+2. 页面跳转与封装：使用 `/guacamole` route 生成 iframe 页面，确保连接参数安全传递。
+3. Guacamole WebSocket 通道：通过 `/connect-guac` 代理连接到内部 Guacamole Lite 服务。
+4. Token 化参数传递：通过 `/api/token-guac` 生成加密 token，用于 Guacamole Client 连接。
+
+### 3.2 容器 Terminal 远程访问
+
+容器终端访问由前端触发“打开终端”操作并调用 `/back/api/containers/{id}/terminal-with-authority` 进行权限校验。权限校验通过后，前端通过 ExecTerminalContext 打开终端弹窗，弹窗使用 Socket.IO 连接 `/socketio/terminal`，后端在 Node 侧调用 `docker exec` 启动 pty，并将输入输出通过 Socket.IO 传输，实现浏览器内的交互式终端。 
+
+关键功能点：
+
+1. 权限校验：后端根据 token/角色/队伍关系判断是否允许访问终端。
+2. 终端连接：Socket.IO 连接 `/socketio/terminal`，以容器 ID 作为 query。
+3. pty 交互：Node 服务启动 `docker exec -it` 并进行输入输出透传。
+4. 多终端管理：ExecTerminalContext 支持同时打开多个终端并管理 z-index。 
+
+## 4. 数据结构设计
+
+### 4.1 Guacamole Token Payload
+
+**表-字段清单：Guacamole Token Payload**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| type | String | 非空 | 连接类型：ssh/rdp/vnc。 |
+| hostname | String | 非空 | 远端主机地址。 |
+| port | String | 非空 | 连接端口。 |
+| username | String | 可空 | SSH/RDP 用户名。 |
+| password | String | 可空 | SSH/RDP 密码。 |
+
+说明：该 payload 由 GuacModal 组织并提交到 `/api/token-guac`，后端使用 AES-256-CBC 加密生成 token。 
+
+### 4.2 VM 连接信息响应结构
+
+**表-字段清单：VM Guac Info**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| host | String | 非空 | VM 可访问地址。 |
+| ssh_port | Int | 非空 | SSH 端口。 |
+| rdp_port | Int | 非空 | RDP 端口。 |
+| vnc_port | Int | 非空 | VNC 端口。 |
+
+说明：VmController 的 `getGuacInfo` 与 `getGuacInfoWithAuthority` 返回此结构。 
+
+### 4.3 容器终端权限校验请求
+
+**表-字段清单：Terminal Authority Request**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| username | String | 可空 | 当前用户名（前端透传）。 |
+| user | Object | 可空 | 支持用户信息（support user）。 |
+| roles | String[] | 可空 | 当前用户角色列表。 |
+
+说明：前端在场景实例列表中会合并用户信息与角色信息，并在请求体中传递给权限校验接口。 
+
+## 5. 类设计与结构关系
+
+### 5.1 类图（Mermaid）
+
+```mermaid
+classDiagram
+    class VmInstancesPage {
+        +handleGuac()
+        +openGuacWindow()
+    }
+    class ContainerInstancesTab {
+        +handleOpenTerminalWithAuthority()
+    }
+    class ExecTerminalContext {
+        +openTerminal()
+        +closeTerminal()
+    }
+    class ExecTerminalModal {
+        +connectSocket()
+        +sendResize()
+    }
+    class GuacModal {
+        +connect()
+        +sendResize()
+    }
+    class VmController {
+        +getGuacInfo()
+        +getGuacInfoWithAuthority()
+    }
+    class ContainersController {
+        +terminalWithAuthority()
+    }
+    class ServerProxy {
+        +proxyConnectGuac()
+        +socketIoTerminal()
+    }
+
+    VmInstancesPage --> VmController
+    VmInstancesPage --> GuacModal
+    ContainerInstancesTab --> ContainersController
+    ContainerInstancesTab --> ExecTerminalContext
+    ExecTerminalContext --> ExecTerminalModal
+    GuacModal --> ServerProxy
+    ExecTerminalModal --> ServerProxy
+```
+
+### 5.2 结构说明
+
+虚拟机 VNC 流程由前端页面触发调用后端 Guac 信息接口，之后通过 `/guacamole` 页面封装和 Guacamole WebSocket 通道连接完成远程桌面展示；容器终端访问则先调用权限校验接口，通过后再打开 ExecTerminalModal 并连接 `/socketio/terminal`。Node 服务承担 Guacamole 代理与终端 WebSocket 的统一接入，使前端的连接路径统一在同一域名下。 
+
+## 6. 关键流程设计（典型业务场景）
+
+### 6.1 典型场景一：虚拟机 VNC 连接
+
+**流程说明**：用户点击“VNC 控制台”后，前端调用 `/back/api/vms/{vm_name}/guac` 获取连接信息，随后通过 `/guacamole` 页面进行 iframe 包装，iframe 内的 Guacamole 前端脚本建立 WebSocket 连接 `/connect-guac` 并渲染远程桌面。 
+
+```mermaid
+sequenceDiagram
+    participant UI as VmInstancesPage
+    participant API as /back/api/vms/{vm_name}/guac
+    participant GuacPage as /guacamole
+    participant Proxy as /connect-guac
+    UI->>API: GET guac info
+    API-->>UI: host + vnc_port
+    UI->>GuacPage: POST form params
+    GuacPage->>Proxy: WebSocket connect
+    Proxy-->>GuacPage: VNC stream
+```
+
+### 6.2 典型场景二：Guacamole Token 生成与连接
+
+**流程说明**：GuacModal 使用 `/api/token-guac` 生成加密 token，随后以 `connect-guac?token=...` 建立 WebSocket 连接，避免将明文连接参数直接暴露在前端。 
+
+```mermaid
+sequenceDiagram
+    participant UI as GuacModal
+    participant TokenAPI as /api/token-guac
+    participant Proxy as /connect-guac
+    UI->>TokenAPI: POST payload
+    TokenAPI-->>UI: token
+    UI->>Proxy: WS connect with token
+    Proxy-->>UI: Guacamole stream
+```
+
+### 6.3 典型场景三：容器终端权限校验与打开
+
+**流程说明**：用户点击“打开终端”后，前端调用 `/back/api/containers/{id}/terminal-with-authority` 校验权限，成功后打开 ExecTerminalModal，Socket.IO 连接 `/socketio/terminal` 并使用 `docker exec` 建立交互。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ContainerInstancesTab
+    participant AuthAPI as /back/api/containers/{id}/terminal-with-authority
+    participant Socket as /socketio/terminal
+    participant Node as Node server
+    UI->>AuthAPI: POST user payload
+    AuthAPI-->>UI: allowed
+    UI->>Socket: socket.io connect (id)
+    Node->>Node: docker exec -it <id> /bin/bash
+    Node-->>UI: terminal output
+```
+
+## 7. 接口实现要点
+
+**接口清单（远程访问代理集成模块）**
+
+| 路径 | 方法 | 功能 | 备注 |
+| --- | --- | --- | --- |
+| `/back/api/vms/{vm_name}/guac` | GET | 获取 VM 远程访问参数 | 返回 host + vnc_port 等。 |
+| `/back/api/vms/{vm_name}/guac-with-authority` | GET | 权限校验后获取连接参数 | 场景实例中使用。 |
+| `/api/token-guac` | POST | 生成 Guacamole token | AES-256-CBC 加密。 |
+| `/guacamole` | GET/POST | Guacamole 页面包装 | 返回 iframe HTML。 |
+| `/connect-guac` | WS | Guacamole WebSocket 代理 | 代理到内部 guac 服务。 |
+| `/back/api/containers/{id}/terminal-with-authority` | GET/POST | 容器终端权限校验 | 通过后允许打开终端。 |
+| `/socketio/terminal` | WS | 容器终端 Socket.IO 入口 | 基于 docker exec。 |
+
+## 8. 设计要点与边界说明
+
+1. **双通道代理**：VNC 通过 Guacamole Lite + `/connect-guac` 代理，终端通过 Socket.IO + `/socketio/terminal` 通道实现。
+2. **Token 化访问**：Guacamole 连接参数加密后再传递，避免明文暴露主机与端口。
+3. **权限隔离**：容器终端访问前置权限检查，避免非授权用户直接连接终端。
+4. **统一入口**：Node 服务统一处理代理与 WebSocket 接入，使前端不需区分内部服务地址。
+5. **范围限制**：本文档只描述 VNC 与 Docker Terminal，不覆盖实例管理或其它运维功能。 
+

--- a/软件设计说明书-镜像管理模块.md
+++ b/软件设计说明书-镜像管理模块.md
@@ -1,0 +1,336 @@
+# 软件设计说明书（镜像管理模块）
+
+## 1. 模块概述与范围
+
+镜像管理模块负责对平台内“容器镜像”与“虚拟机镜像”的统一展示、导入导出、元数据维护与删除，并在必要时提供从镜像快速启动容器或虚拟机的入口。整体架构以前端页面为入口，容器镜像通过 Docker 守护进程获取与操作，虚拟机镜像通过 libvirt/virsh 的存储池目录读取并结合本地 JSON 覆盖配置完善描述信息，同时在后端提供 REST API 以满足列表、增删改查与导入导出等操作需求。模块所涵盖的 UI 页面包括“容器镜像管理”与“虚拟机镜像管理”，对应的后端接口既包括 Laravel 的 `/back/api` 代理，也包括 Next.js 自身的 `/api` 辅助能力。前后端协同的主线以“镜像清单”为核心对象，并衍生“镜像文件上传/下载”“镜像元数据编辑”“按镜像创建实例”等场景。该模块的边界明确：不直接承担容器/虚拟机运行态监控，相关运行态信息由其他子模块负责。 
+
+## 2. 代码范围与文件清单
+
+### 2.1 前端页面与组件
+
+- 容器镜像管理页面：`src/app/scenario/images/page.tsx`
+- 虚拟机镜像管理页面：`src/app/scenario/vm-images/page.tsx`
+- 容器镜像新增/编辑弹窗：`src/components/imagemanagement/ImageFormModal.tsx`
+- 容器创建弹窗（从镜像启动）：`src/components/scenario/CreateContainerModal.tsx`
+- 虚拟机创建弹窗（从镜像启动）：`src/components/vm/CreateVmModal.tsx`
+
+### 2.2 Next.js API（前端侧后端）
+
+- 容器镜像 CRUD：`src/app/api/images/route.ts`
+- 容器镜像导入：`src/app/api/images/import/route.ts`
+- 容器镜像导出：`src/app/api/images/export/route.ts`
+- 虚拟机镜像导入/导出/删除：`src/app/api/vms/images/*`
+- 虚拟机镜像覆盖配置：`src/app/api/vm-image-overrides/route.ts`
+
+### 2.3 业务服务与数据层
+
+- Docker 镜像清单读取：`src/lib/docker.ts`
+- Prisma 数据访问：`src/lib/db/queries.ts`
+- Prisma 数据模型：`src/prisma/schema.prisma`
+- 虚拟机镜像目录定位：`src/lib/virsh.ts`
+- 虚拟机镜像覆盖配置数据：`src/data/vmImageOverrides.json`
+
+### 2.4 Laravel 后端（/back/api）
+
+- Docker 镜像控制器：`back/app/Http/Controllers/Docker/ImagesController.php`
+- Docker 服务封装：`back/app/Services/DockerService.php`
+- Docker 镜像模型：`back/app/Models/Docker/Image.php`
+- API 路由：`back/routes/api.php`
+- 虚拟机镜像控制器：`back/app/Http/Controllers/Vm/VmController.php`
+
+## 3. 功能设计（详细功能点）
+
+### 3.1 容器镜像管理
+
+容器镜像管理页面用于展示当前可用 Docker 镜像，并提供搜索、列显隐、导入/导出与删除等操作。页面加载后通过 `/back/api/images` 获取镜像列表，并根据关键字对名称、版本与描述进行前端过滤；表格支持分页和列显示切换，便于运维或教学人员在镜像数量较多时快速定位目标镜像。此外，页面可通过导入功能上传镜像 tar 包并由后端调用 Docker 载入；导出功能则将指定镜像打包为 tar 并下载到本地。对于需要快速演示或调试的场景，页面提供“启动”入口，通过创建容器弹窗基于镜像启动实例。删除功能在用户确认后调用删除接口删除镜像记录并尝试清理 Docker 本地镜像缓存。 
+
+具体功能点：
+
+1. 镜像列表查询与展示：支持分页、字段展示控制、全量或按条件搜索。
+2. 镜像导入：支持多文件选择，展示上传进度，支持取消上传。
+3. 镜像导出：导出镜像 tar 包，展示下载进度，支持取消下载。
+4. 镜像删除：二次确认后删除镜像并刷新列表。
+5. 镜像启动（容器实例）：从镜像快捷创建容器实例入口，带固定镜像参数。
+6. 刷新操作：手动触发重新获取镜像列表。
+
+### 3.2 虚拟机镜像管理
+
+虚拟机镜像管理页面针对 libvirt 存储池中的镜像文件，提供列表展示、导入导出、元数据编辑与删除能力。镜像列表由 `/back/api/vms/images` 获取，后端从默认存储池读取可用镜像文件并返回名称、大小、状态、修改时间等信息。由于 libvirt 镜像自身缺少业务描述字段，页面会同步读取 `/api/vm-image-overrides` 的覆盖配置，将 JSON 中的 OS 类型和描述补充到 UI 展示，并允许在编辑对话框中更新覆盖配置。导入功能会上传镜像文件到存储池目录；导出会读取存储池文件并生成下载流；删除操作直接删除镜像文件。可选“启动”入口支持从镜像创建虚拟机实例（默认隐藏，由常量控制）。 
+
+具体功能点：
+
+1. 镜像列表查询与展示：支持名称/描述/OS 类型搜索与分页展示。
+2. 镜像导入：多文件上传至默认存储池目录，显示上传进度，支持取消。
+3. 镜像导出：从存储池读取镜像文件并下载，显示下载进度，支持取消。
+4. 镜像编辑：编辑 OS 类型与描述信息，并保存到覆盖配置 JSON。
+5. 镜像删除：确认后删除存储池内镜像文件并刷新列表。
+6. 镜像启动（VM 实例）：从镜像快捷创建 VM（受开关控制）。
+
+### 3.3 统一体验与权限逻辑
+
+镜像管理模块通过统一的表格操作与操作按钮向用户提供一致体验。容器镜像接口支持传入角色与用户 ID 参数以做筛选控制（若调用方提供），虚拟机镜像管理主要依赖存储池访问权限与系统级文件权限。前端在调用接口时统一走 `customFetch` 以附带认证信息，后端通过 Docker 守护进程或系统命令读取实际镜像清单。整体上实现了“镜像清单统一视图 + 导入导出 + 元数据维护 + 实例化入口”的完整闭环。 
+
+## 4. 数据结构设计
+
+### 4.1 容器镜像信息表（Image）
+
+**表-字段清单：Image（Prisma/SQLite）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| id | String | 主键 | 镜像记录唯一 ID。 |
+| name | String | 非空 | 镜像名称（不含版本）。 |
+| type | String | 非空 | 镜像类型，容器镜像通常为 `docker`。 |
+| version | String | 非空 | 版本号或 tag。 |
+| description | String | 非空 | 镜像描述。 |
+| file_name | String | 非空 | 镜像文件名（用于记录上传文件）。 |
+| size | String | 非空 | 镜像大小字符串。 |
+| upload_date | DateTime | 非空 | 上传时间（ISO 形式保存）。 |
+
+说明：该表由 Next.js 的 Prisma 数据访问层维护，用于镜像元数据的持久化与前端展示。Docker 实际镜像信息由 Docker Daemon 返回，在部分场景下用于生成展示数据或与 DB 数据合并。 
+
+### 4.2 虚拟机镜像覆盖配置（vmImageOverrides.json）
+
+**表-字段清单：vmImageOverrides（JSON 映射）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| name (Key) | String | 主键（键名） | 镜像文件名，作为映射 key。 |
+| osType | String | 可空 | 操作系统类型（如 ubuntu/win10）。 |
+| description | String | 可空 | 镜像描述信息。 |
+
+说明：该配置文件作为虚拟机镜像的“业务元数据补充”，与 libvirt 镜像文件本身解耦，便于用户在不改动镜像文件的情况下维护描述信息。 
+
+### 4.3 虚拟机镜像列表结构（后端返回）
+
+**表-字段清单：VmImage（接口响应结构）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| id | String | 非空 | 镜像唯一标识，通常等于文件名。 |
+| name | String | 非空 | 镜像文件名。 |
+| pool | String | 可空 | 存储池名称（默认 default）。 |
+| size | String | 可空 | 镜像大小（以 MB 或 M 表示）。 |
+| path | String | 可空 | 镜像文件完整路径。 |
+| modifiedDate | String | 可空 | 修改时间（ISO 字符串）。 |
+| status | String | 可空 | 状态字段（如 available）。 |
+| osType | String | 可空 | 覆盖配置中的 OS 类型。 |
+| description | String | 可空 | 覆盖配置中的描述。 |
+
+说明：该结构由 `listVmImages` 返回，再由前端与覆盖配置合并后展示。 
+
+### 4.4 容器镜像展示结构（前端 ManagedImage）
+
+**表-字段清单：ManagedImage（前端类型）**
+
+| 字段名 | 类型 | 约束 | 说明 |
+| --- | --- | --- | --- |
+| id | String | 非空 | 镜像唯一 ID（Docker ID 或 DB ID）。 |
+| name | String | 非空 | 镜像名称。 |
+| type | 'docker' \| 'vm' | 非空 | 镜像类型。 |
+| version | String | 非空 | 镜像版本。 |
+| description | String | 非空 | 描述信息。 |
+| fileName | String | 可空 | 镜像文件名。 |
+| size | String | 可空 | 镜像大小（格式化字符串）。 |
+| uploadDate | String | 非空 | 上传时间（ISO 字符串）。 |
+
+说明：该结构用于容器镜像管理页面与相关下游（如创建容器）传参。 
+
+## 5. 类设计与结构关系
+
+### 5.1 类图（Mermaid）
+
+```mermaid
+classDiagram
+    class ImageManagementPage {
+        +fetchImages()
+        +handleImport()
+        +handleExport()
+        +handleDeleteImage()
+        +handleStart()
+    }
+    class VmImageManagementPage {
+        +fetchImages()
+        +handleImport()
+        +handleExport()
+        +handleSave()
+        +handleDelete()
+    }
+    class ImageFormModal {
+        +onSave(image)
+    }
+    class CreateContainerModal {
+        +onCreated()
+    }
+    class CreateVmModal {
+        +fixedImage
+    }
+    class DockerImagesController {
+        +index()
+        +store()
+        +update()
+        +destroy()
+    }
+    class VmController {
+        +listVmImages()
+    }
+    class DockerService {
+        +listImages()
+        +removeImage()
+    }
+    class DockerApi {
+        +GET /api/images
+        +POST /api/images
+        +PUT /api/images
+        +DELETE /api/images
+        +POST /api/images/import
+        +GET /api/images/export
+    }
+    class VmImagesApi {
+        +POST /api/vms/images/import
+        +GET /api/vms/images/export
+        +DELETE /api/vms/images
+    }
+    class VmOverridesApi {
+        +GET /api/vm-image-overrides
+        +POST /api/vm-image-overrides
+    }
+
+    ImageManagementPage --> ImageFormModal
+    ImageManagementPage --> CreateContainerModal
+    ImageManagementPage --> DockerApi
+    ImageManagementPage --> DockerImagesController
+    DockerImagesController --> DockerService
+
+    VmImageManagementPage --> CreateVmModal
+    VmImageManagementPage --> VmController
+    VmImageManagementPage --> VmImagesApi
+    VmImageManagementPage --> VmOverridesApi
+```
+
+### 5.2 结构说明
+
+镜像管理模块在前端层以两个页面组件为主入口。容器镜像管理依赖于 Laravel `/back/api/images` 读取 Docker 列表并进行 CRUD，同时通过 Next.js API 提供导入/导出能力；虚拟机镜像管理依赖 `/back/api/vms/images` 获取存储池镜像清单，再通过 `/api/vm-image-overrides` 完成 OS/描述的补充与编辑，并使用 `/api/vms/images/import|export|delete` 完成文件级导入导出与删除。DockerService 与 VmController 分别封装 Docker 与 virsh 访问细节，使控制器保持轻量；前端则通过 `customFetch` 统一完成鉴权与异常处理。 
+
+## 6. 关键流程设计（典型业务场景）
+
+### 6.1 典型场景一：容器镜像列表加载
+
+**流程说明**：用户进入容器镜像管理页面后，页面调用 `/back/api/images` 拉取 Docker 镜像列表。后端通过 DockerService 获取镜像清单，并根据角色与用户 ID（若提供）筛选结果，最终返回给前端。前端将数据写入状态并渲染表格，同时支持搜索与列显示切换。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ImageManagementPage
+    participant API as /back/api/images
+    participant Svc as DockerService
+    UI->>API: GET /back/api/images
+    API->>Svc: listImages()
+    Svc-->>API: Docker 镜像列表
+    API-->>UI: JSON 镜像数据
+    UI->>UI: 渲染表格、启用搜索/分页
+```
+
+### 6.2 典型场景二：容器镜像导入
+
+**流程说明**：用户点击“导入”后选择镜像 tar 文件，前端使用 `axios` 以 `multipart/form-data` 上传到 `/api/images/import`。Next.js API 使用 Busboy 解析流并调用 Docker `loadImage` 导入镜像；导入成功后刷新列表。该流程以内存流式处理为主，避免在前端先落地文件。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ImageManagementPage
+    participant API as /api/images/import
+    participant Docker as Docker Daemon
+    UI->>API: POST multipart/form-data
+    API->>Docker: loadImage(stream)
+    Docker-->>API: 导入完成
+    API-->>UI: ok
+    UI->>UI: 刷新列表
+```
+
+### 6.3 典型场景三：容器镜像导出
+
+**流程说明**：用户在列表中点击“导出”，前端请求 `/api/images/export?name=镜像:版本`。后端通过 Docker API 获取镜像 tar 流并以附件方式返回，浏览器触发下载。前端展示下载进度，可选择中止下载。 
+
+```mermaid
+sequenceDiagram
+    participant UI as ImageManagementPage
+    participant API as /api/images/export
+    participant Docker as Docker Daemon
+    UI->>API: GET /api/images/export?name=... 
+    API->>Docker: image.get()
+    Docker-->>API: tar stream
+    API-->>UI: tar stream (download)
+    UI->>UI: 触发保存/进度显示
+```
+
+### 6.4 典型场景四：虚拟机镜像列表与覆盖信息合并
+
+**流程说明**：虚拟机镜像管理页面进入时并行拉取 `/back/api/vms/images` 与 `/api/vm-image-overrides`。后者是 JSON 映射，用来补充镜像的 OS 类型与描述；前端合并并渲染表格。此方式使镜像文件与描述信息解耦，便于管理。 
+
+```mermaid
+sequenceDiagram
+    participant UI as VmImageManagementPage
+    participant VMAPI as /back/api/vms/images
+    participant OVAPI as /api/vm-image-overrides
+    UI->>VMAPI: GET /back/api/vms/images
+    UI->>OVAPI: GET /api/vm-image-overrides
+    VMAPI-->>UI: 镜像文件列表
+    OVAPI-->>UI: 覆盖配置
+    UI->>UI: 合并 osType/description 并渲染
+```
+
+### 6.5 典型场景五：虚拟机镜像元数据编辑
+
+**流程说明**：用户点击“编辑”打开对话框并选择 OS 类型或自定义描述。保存时向 `/api/vm-image-overrides` POST 数据，后端读取 JSON 并更新对应条目，随后前端更新内存中的镜像列表，确保界面即时刷新。 
+
+```mermaid
+sequenceDiagram
+    participant UI as VmImageManagementPage
+    participant OVAPI as /api/vm-image-overrides
+    UI->>OVAPI: POST {name, osType, description}
+    OVAPI-->>UI: success
+    UI->>UI: 更新本地列表渲染
+```
+
+### 6.6 典型场景六：虚拟机镜像删除
+
+**流程说明**：用户确认删除后，前端调用 `/api/vms/images?name=...` 触发删除。后端定位存储池目录并删除镜像文件，随后前端刷新镜像列表。该流程为文件级删除，不涉及 libvirt 运行态实例。 
+
+```mermaid
+sequenceDiagram
+    participant UI as VmImageManagementPage
+    participant API as /api/vms/images
+    participant FS as VM Image Directory
+    UI->>API: DELETE /api/vms/images?name=...
+    API->>FS: unlink(image file)
+    FS-->>API: 删除完成
+    API-->>UI: ok
+    UI->>UI: 刷新列表
+```
+
+## 7. 接口实现要点
+
+**接口清单（镜像管理模块）**
+
+| 路径 | 方法 | 功能 | 备注 |
+| --- | --- | --- | --- |
+| `/back/api/images` | GET | 获取容器镜像列表 | 可携带 role/userId 过滤。 |
+| `/back/api/images` | POST | 新增镜像元数据 | 写入镜像元数据表。 |
+| `/back/api/images` | PUT | 更新镜像元数据 | 更新镜像元数据表。 |
+| `/back/api/images` | DELETE | 删除镜像 | 先尝试删除 Docker 镜像，再删除 DB 记录。 |
+| `/api/images/import` | POST | 导入容器镜像 | 上传 tar 并调用 Docker `loadImage`。 |
+| `/api/images/export` | GET | 导出容器镜像 | 生成 tar 流响应，支持 Content-Length。 |
+| `/back/api/vms/images` | GET | 获取虚拟机镜像列表 | 读取 virsh 存储池目录。 |
+| `/api/vms/images/import` | POST | 导入虚拟机镜像 | 上传文件到存储池目录。 |
+| `/api/vms/images/export` | GET | 导出虚拟机镜像 | 读取存储池文件并下载。 |
+| `/api/vms/images` | DELETE | 删除虚拟机镜像 | 删除存储池镜像文件。 |
+| `/api/vm-image-overrides` | GET | 获取虚拟机镜像覆盖配置 | 读取 JSON 映射。 |
+| `/api/vm-image-overrides` | POST | 保存虚拟机镜像覆盖配置 | 更新 JSON 映射项。 |
+
+## 8. 设计要点与边界说明
+
+1. **数据源分层**：容器镜像信息来自 Docker Daemon，虚拟机镜像信息来自 libvirt 存储池文件系统，覆盖配置来自 JSON 文件。三类数据源职责清晰，减少数据库对镜像文件的强依赖。
+2. **导入导出流式处理**：使用 Busboy 与 ReadableStream 流式处理，降低大文件传输的内存消耗，并提供上传/下载进度反馈。
+3. **元数据解耦**：虚拟机镜像业务描述不写入镜像文件本体，而是通过 JSON 覆盖文件维护，便于用户随时调整。
+4. **权限与安全**：容器镜像列表接口支持角色过滤；虚拟机镜像操作依赖系统权限与存储池读写权限，需在部署时确保适当的运行权限。
+5. **模块边界**：镜像管理模块负责镜像“生命周期与元数据管理”，不直接处理容器/虚拟机运行态的监控与高阶调度，这些由其他子系统完成。
+


### PR DESCRIPTION
### Motivation

- Provide a root-level software design document describing the remote access proxy integration module (VM VNC/Guacamole and Docker terminal) so developers understand end-to-end flows, components and security boundaries. 
- Capture how frontend components, Next.js APIs, the Node proxy and Laravel back-end endpoints map to Guacamole and terminal behaviors to remove ambiguity when maintaining or extending remote access. 

### Description

- Add a new design specification at the repository root: `软件设计说明书-远程访问代理集成模块.md`, documenting module scope, file mappings, data structures, class diagrams (Mermaid), sequence diagrams and an API inventory. 
- Documented front-end components and pages (for example `src/components/vm/GuacModal.tsx`, `src/components/scenario/ExecTerminalModal.tsx`, `src/contexts/ExecTerminalContext.tsx`, `src/app/guacamole/route.ts`, `src/app/api/token-guac/route.ts`) and mapped them to Node proxy logic (`src/server.js`) and Laravel controllers (for example `back/app/Http/Controllers/Vm/VmController.php`, `back/app/Http/Controllers/Docker/ContainersController.php`). 
- Specified key flows for VM VNC (token generation via `POST /api/token-guac`, iframe `/guacamole`, WebSocket proxy at `/connect-guac`) and container terminal (permission check `POST /back/api/containers/{id}/terminal-with-authority`, Socket.IO at `/socketio/terminal`, `docker exec` pty handling). 
- Enumerated payload shapes and interface list including ` /api/token-guac `, ` /connect-guac `, ` /socketio/terminal ` and back-end authority endpoints to clarify security and boundary concerns. 

### Testing

- No automated tests were run for this change because it is documentation-only. 
- No automated test failures occurred because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c78a8cef08320be7283e0ed9fd1cc)